### PR TITLE
Replace ORDER BY by INTERNAL SORT BY in geomcache query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+build/
+*.log
 *.swp
 *.swo

--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -31,7 +31,7 @@ using util::geo::latLngToWebMerc;
 // " UNION"
 // "     { ?osm_id <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
 // "<https://www.openstreetmap.org/relation> }"
-// " } ORDER BY ?geometry LIMIT "
+// " } INTERNAL SORT BY ?geometry LIMIT "
 // "18446744073709551615";
 //
 // const static std::string QUERY = "PREFIX osmway:"
@@ -44,7 +44,7 @@ using util::geo::latLngToWebMerc;
 // "SELECT ?geometry WHERE {"
 // " ?osm_id <https://www.openstreetmap.org/wiki/Key:building> ?a . "
 // " ?osm_id <http://www.opengis.net/ont/geosparql#hasGeometry> ?geometry  "
-// " } ORDER BY ?geometry";
+// " } INTERNAL SORT BY ?geometry";
 
 // const static std::string COUNT_QUERY =
 // "SELECT (COUNT(?geometry) as ?count) WHERE {"
@@ -56,7 +56,7 @@ using util::geo::latLngToWebMerc;
 // "SELECT ?geometry WHERE {"
 // " ?osm_id <https://www.openstreetmap.org/wiki/Key:highway> ?a . "
 // " ?osm_id <http://www.opengis.net/ont/geosparql#hasGeometry> ?geometry  "
-// " } ORDER BY ?geometry";
+// " } INTERNAL SORT BY ?geometry";
 
 // const static std::string COUNT_QUERY =
 // "SELECT (COUNT(?geometry) as ?count) WHERE {"
@@ -67,7 +67,7 @@ using util::geo::latLngToWebMerc;
 const static std::string QUERY =
     "SELECT ?geometry WHERE {"
     " ?osm_id <http://www.opengis.net/ont/geosparql#hasGeometry> ?geometry "
-    " } ORDER BY ?geometry";
+    " } INTERNAL SORT BY ?geometry";
 
 const static std::string COUNT_QUERY =
     "SELECT (COUNT(?osm_id) as ?count) WHERE {"

--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -23,47 +23,6 @@ using petrimaps::GeomCache;
 using util::geo::FPoint;
 using util::geo::latLngToWebMerc;
 
-// const static std::string QUERY =
-// "SELECT ?geometry WHERE {"
-// " ?osm_id <http://www.opengis.net/ont/geosparql#hasGeometry> ?geometry ."
-// "   { ?osm_id <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
-// "<https://www.openstreetmap.org/node> }"
-// " UNION"
-// "     { ?osm_id <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
-// "<https://www.openstreetmap.org/relation> }"
-// " } INTERNAL SORT BY ?geometry LIMIT "
-// "18446744073709551615";
-//
-// const static std::string QUERY = "PREFIX osmway:"
-// "<https://www.openstreetmap.org/way/>" " PREFIX geo:"
-// "<http://www.opengis.net/ont/geosparql#> " " PREFIX osmrel:"
-// "<https://www.openstreetmap.org/relation/> " " SELECT ?geom WHERE {"
-// "osmway:170488516 geo:hasGeometry ?geom } ";
-
-// const static std::string QUERY =
-// "SELECT ?geometry WHERE {"
-// " ?osm_id <https://www.openstreetmap.org/wiki/Key:building> ?a . "
-// " ?osm_id <http://www.opengis.net/ont/geosparql#hasGeometry> ?geometry  "
-// " } INTERNAL SORT BY ?geometry";
-
-// const static std::string COUNT_QUERY =
-// "SELECT (COUNT(?geometry) as ?count) WHERE {"
-// " ?osm_id <https://www.openstreetmap.org/wiki/Key:building> ?a . "
-// " ?osm_id <http://www.opengis.net/ont/geosparql#hasGeometry> ?geometry . "
-// " }";
-
-// const static std::string QUERY =
-// "SELECT ?geometry WHERE {"
-// " ?osm_id <https://www.openstreetmap.org/wiki/Key:highway> ?a . "
-// " ?osm_id <http://www.opengis.net/ont/geosparql#hasGeometry> ?geometry  "
-// " } INTERNAL SORT BY ?geometry";
-
-// const static std::string COUNT_QUERY =
-// "SELECT (COUNT(?geometry) as ?count) WHERE {"
-// " ?osm_id <https://www.openstreetmap.org/wiki/Key:highway> ?a . "
-// " ?osm_id <http://www.opengis.net/ont/geosparql#hasGeometry> ?geometry . "
-// " }";
-
 const static std::string QUERY =
     "SELECT ?geometry WHERE {"
     " ?osm_id <http://www.opengis.net/ont/geosparql#hasGeometry> ?geometry "


### PR DESCRIPTION
See
https://github.com/ad-freiburg/qlever/commit/aee40945a10a66aa24b1748b1652b4d51c2eec0e

Since that commit, the cache query that asks for all geometries took very long for oms-planet because it uses ORDER BY, which has since become a slow operation. For the purpose of the caching, INTERNAL SORT BY is just as good, but faster (and also pinned to the cache for our QLever instance).