### PR TITLE
Towards customizable SPARQL queries for the geom cache

### DIFF
--- a/src/qlever-petrimaps/GeomCache.h
+++ b/src/qlever-petrimaps/GeomCache.h
@@ -106,6 +106,10 @@ class GeomCache {
   static size_t writeCbString(void* contents, size_t size, size_t nmemb,
                               void* userp);
 
+  // Get the right SPARQL query for the given backend.
+  const std::string& getQuery(const std::string& backendUrl) const;
+  const std::string& getCountQuery(const std::string& backendUrl) const;
+
   std::string requestIndexHash();
 
   std::string queryUrl(std::string query, size_t offset, size_t limit) const;

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -379,7 +379,13 @@ std::string Requestor::prepQuery(std::string query) const {
 
 // _____________________________________________________________________________
 std::string Requestor::prepQueryRow(std::string query, uint64_t row) const {
-  query += " OFFSET " + std::to_string(row) + " LIMIT 1";
+  // replace first select
+  std::regex expr("select[^{]*\\?[A-Z0-9_\\-+]*+[^{]*\\s*\\{",
+                  std::regex_constants::icase);
+
+  query = std::regex_replace(query, expr, "SELECT * {$&",
+                             std::regex_constants::format_first_only) + "}";
+  query += "OFFSET " + std::to_string(row) + " LIMIT 1";
   return query;
 }
 

--- a/web/script.js
+++ b/web/script.js
@@ -205,9 +205,12 @@ function loadMap(id, bounds, numObjects) {
         if (map.hasLayer(objectsLayer)) styles = "objects";
 
         fetch('pos?x=' + pos.x + "&y=" + pos.y + "&id=" + id + "&rad=" + (100 * Math.pow(2, 14 - map.getZoom())) + '&width=' + w + '&height=' + h + '&bbox=' + bounds.join(',') + '&styles=' + styles)
-          .then(response => response.json())
+          .then(response => {
+              if (!response.ok) return response.text().then(text => {throw new Error(text)});
+              return response.json();
+            })
           .then(data => openPopup(data))
-          .catch(error => showError(genError));
+          .catch(error => showError(error));
         });
 
     map.on('zoomend', function(e) {


### PR DESCRIPTION
The SPARQL queries for the `GeomCache` depend on the backend. We currently have different queries for OSM and for Wikidata. So far, it was hard-coded in several places, which of the queries was chosen. This decition now happens in two dedicated methods `getQuery()` and `getQueryCount()`. The mechanism is used to use the Wikidata queries also for dblp-plus (which so far did not work).

TODO: The MapView for https://qlever.cs.uni-freiburg.de/dblp-plus/WF9LE4 now indeed works. But when you click on one of the points, the info box is not shown, but instead "Session has been removed from cache". Why?