### PR TITLE
Add option to fetch geometries via `geo:hasGeometry/geo:asWKT`

### DIFF
--- a/src/qlever-petrimaps/GeomCache.h
+++ b/src/qlever-petrimaps/GeomCache.h
@@ -146,6 +146,7 @@ class GeomCache {
   std::fstream _qidToIdF;
 
   size_t _totalSize = 0;
+  size_t _geometryDuplicates = 0;
 
   IdMapping _lastQidToId;
 

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -112,8 +112,16 @@ void Requestor::request(const std::string& qry) {
 
   LOG(INFO) << "[REQUESTOR] ... done";
 
-  LOG(INFO) << "[REQUESTOR] Point BBox: " << util::geo::getWKT(pointBbox);
-  LOG(INFO) << "[REQUESTOR] Line BBox: " << util::geo::getWKT(lineBbox);
+  if (pointBbox.getLowerLeft().getX() > pointBbox.getUpperRight().getX()) {
+    LOG(INFO) << "[REQUESTOR] Point BBox: <none)";
+  } else {
+    LOG(INFO) << "[REQUESTOR] Point BBox: " << util::geo::getWKT(pointBbox);
+  }
+  if (lineBbox.getLowerLeft().getX() > lineBbox.getUpperRight().getX()) {
+    LOG(INFO) << "[REQUESTOR] Line BBox: <none>";
+  } else {
+    LOG(INFO) << "[REQUESTOR] Line BBox: " << util::geo::getWKT(lineBbox);
+  }
   LOG(INFO) << "[REQUESTOR] Building grid...";
 
   double GRID_SIZE = 65536;


### PR DESCRIPTION
So far, the code supported getting the geometries via `geo:hasGeometry` (old osm2rdf style) and via `wdt:P625` (Wikidata style). Since November, the TTLs provided on https:/osm2rdf.cs.uni-freiburg.de provide the geometries via geo:hasGeometry/geo:asWKT, which is now also supported.

TODO: The selection between is currently hard-coded, based on the name of the backend. We should find a more elegant and robust mechanism for this.