### PR TITLE
Refactor queries for fetching&counting the geometries

### DIFF
--- a/src/qlever-petrimaps/GeomCache.h
+++ b/src/qlever-petrimaps/GeomCache.h
@@ -118,7 +118,7 @@ class GeomCache {
 
   // Get the right SPARQL query for the given backend.
   const std::string& getQuery(const std::string& backendUrl) const;
-  const std::string& getCountQuery(const std::string& backendUrl) const;
+  std::string getCountQuery(const std::string& backendUrl) const;
 
   std::string requestIndexHash();
 


### PR DESCRIPTION
There are now three predefined queries for fetching the geometries from a SPARQL endpoint: one using `geo:asWKT` (the default), one using `wdt:P525` (used for backends where the name starts with `wikidata`), and one using a `SERVICE` request to Wikidata (used for backends where the name starts with `dblp`). Apart from these differences, the queries have the exact same structure. The query for **counting** the number of geometries is now automatically derived from the fetching query, in a way that is as efficient as possible (in particular, more efficient than before).