### PR TITLE
Deploy

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,60 @@
+name: Docker build and publish
+
+on:
+  push:
+    branches: [ master ]
+
+concurrency:
+  # We want all containers to be pushed. Don't cancel any concurent jobs.
+  group: '${{ github.workflow }} @ ${{ github.sha}}'
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Get short sha
+        id: sha
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          # We build multiplatform images which have an image index above the
+          # image manifests. Attach the annotations directly to the image index.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: "index"
+
+      - name: Build and push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runtime
+          platforms: linux/amd64,linux/arm64
+          push: true
+          # We have to explicitly add the "qlever:latest" tag for it to work correctly,
+          # see e.g. https://stackoverflow.com/questions/27643017/do-i-need-to-manually-tag-latest-when-pushing-to-docker-public-repository
+          tags: >
+            adfreiburg/qlever-petrimaps:latest,
+            adfreiburg/qlever-petrimaps:${{ github.ref_name }},
+            adfreiburg/qlever-petrimaps:commit-${{ steps.sha.outputs.sha_short }},
+
+          # Set Annotations and Labels that conform to the OpenContainers
+          # Annotations Spec
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -22,6 +22,19 @@ ADD web /web
 
 RUN mkdir build && cd build && cmake .. && make -j8
 
-WORKDIR /
+FROM ubuntu:24.04 AS runtime
 
-ENTRYPOINT ["./build/petrimaps"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /
+RUN apt update &&\
+    apt install -y --no-install-recommends \
+      ca-certificates \
+      xxd \
+      libgomp1 \
+      libpng-dev \
+      libcurl4-gnutls-dev &&\
+    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /build/petrimaps /petrimaps
+
+ENTRYPOINT ["/petrimaps"]


### PR DESCRIPTION
The maps instance can now be configured (ad-freiburg/qlever-ui#106) in qlever-ui. It might be nice to provide a docker image of qlever-pretrimaps for people to host their own instance.

This PR adds a workflow that automatically builds an image and pushes it to the docker registry. Some secrets need to be set for this to work though. The PR also adds a smaller runtime container, which is also used in CI.