### PR TITLE
Parse folded POINT geometries from QLever IDs dynamically

### DIFF
--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -174,18 +174,18 @@ void GeomCache::parse(const char *c, size_t size) {
                             sizeof(IdMapping));
             _qidToIdFSize++;
           } else if ((p = _dangling.rfind("POINT(", 1)) != std::string::npos) {
-            _curUniqueGeom++;
-            size_t i = 0;
-            p = parseMultiPoint(_dangling, p + 4, std::string::npos, &i);
+            // _curUniqueGeom++;
+            // size_t i = 0;
+            // p = parseMultiPoint(_dangling, p + 4, std::string::npos, &i);
 
-            // dummy element to keep sync
-            if (i == 0) {
-              IdMapping idm{0, std::numeric_limits<ID_TYPE>::max()};
-              _lastQidToId = idm;
-              _qidToIdF.write(reinterpret_cast<const char *>(&idm),
-                              sizeof(IdMapping));
-              _qidToIdFSize++;
-            }
+            // // dummy element to keep sync
+            // if (i == 0) {
+              // IdMapping idm{0, std::numeric_limits<ID_TYPE>::max()};
+              // _lastQidToId = idm;
+              // _qidToIdF.write(reinterpret_cast<const char *>(&idm),
+                              // sizeof(IdMapping));
+              // _qidToIdFSize++;
+            // }
           } else if ((p = _dangling.rfind("MULTIPOINT(", 1)) !=
                      std::string::npos) {
             _curUniqueGeom++;
@@ -408,6 +408,10 @@ void GeomCache::parseIds(const char *c, size_t size) {
                   << " (open) polygons (with " << _linePointsFSize
                   << " points), " << _geometryDuplicates << " duplicates)";
       }
+
+      uint8_t type = (_curId.val & (uint64_t(15) << 60)) >> 60;
+
+      if (type == 8) continue;
 
       if (_curIdRow < _qidToId.size() && _qidToId[_curIdRow].qid == 0) {
         // if we have two consecutive and equivalent QLever ids, the geometry

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -66,12 +66,17 @@ void Requestor::request(const std::string& qry) {
   _objects = ret.first;
   _numObjects = ret.second;
 
+  LOG(INFO) << "[REQUESTOR] ... done, got "
+            << _objects.size() << " objects.";
+
+  LOG(INFO) << "[REQUESTOR] Retrieving points dynamically from query...";
+
   // dynamic points present in query
   _dynamicPoints = getDynamicPoints(reader._ids);
   _numObjects += _dynamicPoints.size();
 
   LOG(INFO) << "[REQUESTOR] ... done, got "
-            << _objects.size() + _dynamicPoints.size() << " objects.";
+            << _dynamicPoints.size() << " points.";
 
   LOG(INFO) << "[REQUESTOR] Calculating bounding box of result...";
 

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -2,9 +2,9 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
+#include <algorithm>
 #include <cstring>
 #include <iostream>
-#include <algorithm>
 #include <regex>
 #include <sstream>
 
@@ -65,7 +65,12 @@ void Requestor::request(const std::string& qry) {
   const auto& ret = _cache->getRelObjects(reader._ids);
   _objects = ret.first;
   _numObjects = ret.second;
-  LOG(INFO) << "[REQUESTOR] ... done, got " << _objects.size() << " objects.";
+
+  // dynamic points present in query
+  _dynamicPoints = getDynamicPoints(reader._ids);
+
+  LOG(INFO) << "[REQUESTOR] ... done, got "
+            << _objects.size() + _dynamicPoints.size() << " objects.";
 
   LOG(INFO) << "[REQUESTOR] Calculating bounding box of result...";
 
@@ -95,6 +100,18 @@ void Requestor::request(const std::string& qry) {
             util::geo::extendBox(_cache->getLineBBox(lId), lineBoxes[t]);
         numLines[t]++;
       }
+    }
+  }
+
+  batch = ceil(static_cast<double>(_dynamicPoints.size()) / NUM_THREADS);
+
+#pragma omp parallel for num_threads(NUM_THREADS) schedule(static)
+  for (size_t t = 0; t < NUM_THREADS; t++) {
+    for (size_t i = batch * t; i < batch * (t + 1) && i < _dynamicPoints.size();
+         i++) {
+      auto geom = _dynamicPoints[i].first;
+
+      pointBoxes[t] = util::geo::extendBox(geom, pointBoxes[t]);
     }
   }
 
@@ -166,7 +183,7 @@ void Requestor::request(const std::string& qry) {
   {
 #pragma omp section
     {
-      size_t j = _objects.size();
+      size_t j = _objects.size() + _dynamicPoints.size();
 
       for (size_t i = 0; i < _objects.size(); i++) {
         const auto& p = _objects[i];
@@ -175,8 +192,7 @@ void Requestor::request(const std::string& qry) {
 
         size_t clusterI = 0;
         // cluster if they have same geometry, don't do for multigeoms
-        while (i < _objects.size() - 1 && geomId == _objects[i + 1].first &&
-               p.second != _objects[i + 1].second) {
+        while (i < _objects.size() - 1 && geomId == _objects[i + 1].first) {
           clusterI++;
           i++;
         }
@@ -184,13 +200,48 @@ void Requestor::request(const std::string& qry) {
         if (clusterI > 0) {
           for (size_t m = 0; m < clusterI; m++) {
             const auto& p = _objects[i - m];
-            auto geomId = p.first;
-            _pgrid.add(_cache->getPoints()[geomId], j);
+            _pgrid.add(_cache->getPoints()[p.first], j);
             _clusterObjects.push_back({i - m, {m, clusterI}});
             j++;
           }
         } else {
           _pgrid.add(_cache->getPoints()[geomId], i);
+        }
+
+        // every 100000 objects, check memory...
+        if (i % 100000 == 0) {
+          try {
+            checkMem(1, _maxMemory);
+          } catch (...) {
+#pragma omp critical
+            { ePtr = std::current_exception(); }
+            break;
+          }
+        }
+      }
+
+      for (size_t i = 0; i < _dynamicPoints.size(); i++) {
+        const auto& p = _dynamicPoints[i];
+        auto geom = p.first;
+
+        size_t clusterI = 0;
+        // cluster if they have same geometry, don't do for multigeoms
+        while (i < _dynamicPoints.size() - 1 &&
+               geom == _dynamicPoints[i + 1].first) {
+          clusterI++;
+          i++;
+        }
+
+        if (clusterI > 0) {
+          for (size_t m = 0; m < clusterI; m++) {
+            const auto& p = _dynamicPoints[i - m];
+            auto geom = p.first;
+            _pgrid.add(geom, j);
+            _clusterObjects.push_back({i - m + _objects.size(), {m, clusterI}});
+            j++;
+          }
+        } else {
+          _pgrid.add(geom, i + _objects.size());
         }
 
         // every 100000 objects, check memory...
@@ -388,7 +439,8 @@ std::string Requestor::prepQuery(std::string query) const {
   }
 
   query = std::regex_replace(query, expr, "SELECT " + var + " WHERE {$&",
-                             std::regex_constants::format_first_only) + "}";
+                             std::regex_constants::format_first_only) +
+          "}";
 
   query += " LIMIT 18446744073709551615";
 
@@ -402,7 +454,8 @@ std::string Requestor::prepQueryRow(std::string query, uint64_t row) const {
                   std::regex_constants::icase);
 
   query = std::regex_replace(query, expr, "SELECT * {$&",
-                             std::regex_constants::format_first_only) + "}";
+                             std::regex_constants::format_first_only) +
+          "}";
   query += " OFFSET " + std::to_string(row) + " LIMIT 1";
   return query;
 }
@@ -447,12 +500,15 @@ const ResObj Requestor::getNearest(util::geo::DPoint rp, double rad, double res,
       for (size_t idx = 0; idx < ret.size(); idx++) {
         auto i = ret[idx];
         util::geo::FPoint p;
-        if (i >= _objects.size()) {
-          size_t cid = i - _objects.size();
+        if (i >= _objects.size() + _dynamicPoints.size()) {
+          size_t cid = i - _objects.size() - _dynamicPoints.size();
           auto dp = clusterGeom(cid, res);
           p = {dp.getX(), dp.getY()};
         } else {
-          p = _cache->getPoints()[_objects[i].first];
+          if (i < _objects.size())
+            p = _cache->getPoints()[_objects[i].first];
+          else
+            p = _dynamicPoints[i - _objects.size()].first;
         }
 
         if (!util::geo::contains(p, fbox)) continue;
@@ -569,19 +625,32 @@ const ResObj Requestor::getNearest(util::geo::DPoint rp, double rad, double res,
 
   if (dBest < rad && dBest <= dBestL) {
     size_t row = 0;
-    if (nearest >= _objects.size())
-      row = _objects[_clusterObjects[nearest - _objects.size()].first].second;
-    else
-      row = _objects[nearest].second;
+    if (nearest >= _objects.size() + _dynamicPoints.size()) {
+      auto id =
+          _clusterObjects[nearest - _objects.size() - _dynamicPoints.size()]
+              .first;
+      if (id >= _objects.size())
+        row = _dynamicPoints[id - _objects.size()].second;
+      else
+        row = _objects[id].second;
+    } else {
+      if (nearest < _objects.size())
+        row = _objects[nearest].second;
+      else
+        row = _dynamicPoints[nearest - _objects.size()].second;
+    }
 
     auto points = geomPointGeoms(nearest, res);
 
     return {true,
-            nearest >= _objects.size() ? nearest - _objects.size() : nearest,
+            nearest >= _objects.size() + _dynamicPoints.size()
+                ? nearest - _objects.size() - _dynamicPoints.size()
+                : nearest,
             points.size() == 1 ? points[0] : util::geo::centroid(points),
             requestRow(row),
             points,
-            geomLineGeoms(nearest, rad / 10), geomPolyGeoms(nearest, rad / 10)};
+            geomLineGeoms(nearest, rad / 10),
+            geomPolyGeoms(nearest, rad / 10)};
   }
 
   if (dBestL < rad && dBestL <= dBest) {
@@ -592,18 +661,24 @@ const ResObj Requestor::getNearest(util::geo::DPoint rp, double rad, double res,
     const auto& dline = extractLineGeom(lineId);
 
     if (isArea && util::geo::contains(rp, util::geo::DPolygon(dline))) {
-      return {true,  nearestL,
-              {frp.getX(), frp.getY()}, requestRow(_objects[nearestL].second),
-                geomPointGeoms(nearestL, res),
-              geomLineGeoms(nearestL, rad / 10), geomPolyGeoms(nearestL, rad / 10)};
+      return {true,
+              nearestL,
+              {frp.getX(), frp.getY()},
+              requestRow(_objects[nearestL].second),
+              geomPointGeoms(nearestL, res),
+              geomLineGeoms(nearestL, rad / 10),
+              geomPolyGeoms(nearestL, rad / 10)};
     } else {
       if (isArea) {
         auto p = util::geo::PolyLine<double>(dline).projectOn(rp).p;
         auto fp = util::geo::DPoint(p.getX(), p.getY());
-        return {true, nearestL,
-                fp, requestRow(_objects[nearestL].second),
+        return {true,
+                nearestL,
+                fp,
+                requestRow(_objects[nearestL].second),
                 geomPointGeoms(nearestL, res),
-                geomLineGeoms(nearestL, rad / 10), geomPolyGeoms(nearestL, rad / 10)};
+                geomLineGeoms(nearestL, rad / 10),
+                geomPolyGeoms(nearestL, rad / 10)};
       } else {
         auto p = util::geo::PolyLine<double>(dline).projectOn(rp).p;
         auto fp = util::geo::DPoint(p.getX(), p.getY());
@@ -627,6 +702,11 @@ const ResObj Requestor::getGeom(size_t id, double rad) const {
   if (!_cache->ready()) {
     throw std::runtime_error("Geom cache not ready");
   }
+
+  if (id >= _objects.size()) {
+    return {true, id, {0, 0}, {}, geomPointGeoms(id, rad / 10), {}, {}};
+  }
+
   auto obj = _objects[id];
 
   if (obj.first >= I_OFFSET) {
@@ -635,12 +715,30 @@ const ResObj Requestor::getGeom(size_t id, double rad) const {
     bool isArea = Requestor::isArea(lineId);
 
     if (isArea) {
-      return {true, id, {0, 0}, {}, geomPointGeoms(id, rad / 10), geomLineGeoms(id, rad / 10), geomPolyGeoms(id, rad / 10)};
+      return {true,
+              id,
+              {0, 0},
+              {},
+              geomPointGeoms(id, rad / 10),
+              geomLineGeoms(id, rad / 10),
+              geomPolyGeoms(id, rad / 10)};
     } else {
-      return {true, id, {0, 0}, {}, geomPointGeoms(id, rad / 10), geomLineGeoms(id, rad / 10), geomPolyGeoms(id, rad / 10)};
+      return {true,
+              id,
+              {0, 0},
+              {},
+              geomPointGeoms(id, rad / 10),
+              geomLineGeoms(id, rad / 10),
+              geomPolyGeoms(id, rad / 10)};
     }
   } else {
-    return {true, id, {0, 0}, {}, geomPointGeoms(id, rad / 10), geomLineGeoms(id, rad / 10), geomPolyGeoms(id, rad / 10)};
+    return {true,
+            id,
+            {0, 0},
+            {},
+            geomPointGeoms(id, rad / 10),
+            geomLineGeoms(id, rad / 10),
+            geomPolyGeoms(id, rad / 10)};
   }
 }
 
@@ -693,19 +791,24 @@ util::geo::MultiLine<double> Requestor::geomLineGeoms(size_t oid,
   // catch multigeometries
   for (size_t i = oid;
        i < _objects.size() && _objects[i].second == _objects[oid].second; i++) {
-    if (_objects[i].first < I_OFFSET || Requestor::isArea(_objects[i].first - I_OFFSET)) continue;
+    if (_objects[i].first < I_OFFSET ||
+        Requestor::isArea(_objects[i].first - I_OFFSET))
+      continue;
     const auto& fline = extractLineGeom(_objects[i].first - I_OFFSET);
     polys.push_back(util::geo::simplify(fline, eps));
   }
 
-if (oid > 0) {
-  for (size_t i = oid - 1;
-       i < _objects.size() && _objects[i].second == _objects[oid].second; i--) {
-    if (_objects[i].first < I_OFFSET || Requestor::isArea(_objects[i].first - I_OFFSET)) continue;
-    const auto& fline = extractLineGeom(_objects[i].first - I_OFFSET);
-    polys.push_back(util::geo::simplify(fline, eps));
+  if (oid > 0) {
+    for (size_t i = oid - 1;
+         i < _objects.size() && _objects[i].second == _objects[oid].second;
+         i--) {
+      if (_objects[i].first < I_OFFSET ||
+          Requestor::isArea(_objects[i].first - I_OFFSET))
+        continue;
+      const auto& fline = extractLineGeom(_objects[i].first - I_OFFSET);
+      polys.push_back(util::geo::simplify(fline, eps));
+    }
   }
-}
 
   return polys;
 }
@@ -717,15 +820,20 @@ util::geo::MultiPoint<double> Requestor::geomPointGeoms(size_t oid) const {
 
 // _____________________________________________________________________________
 util::geo::MultiPoint<double> Requestor::geomPointGeoms(size_t oid,
-                                                       double res) const {
+                                                        double res) const {
   std::vector<util::geo::DPoint> points;
 
-  if (!(res < 0) && oid >= _objects.size()) {
-    return {clusterGeom(oid - _objects.size(), res)};
+  if (!(res < 0) && oid >= _objects.size() + _dynamicPoints.size()) {
+    return {clusterGeom(oid - _objects.size() - _dynamicPoints.size(), res)};
+  }
+
+  if (oid >= _objects.size() + _dynamicPoints.size()) {
+    oid = _clusterObjects[oid - _objects.size() - _dynamicPoints.size()].first;
   }
 
   if (oid >= _objects.size()) {
-    oid = _clusterObjects[oid - _objects.size()].first;
+    points.push_back({_dynamicPoints[oid - _objects.size()].first.getX(),
+                      _dynamicPoints[oid - _objects.size()].first.getY()});
   }
 
   // catch multigeometries
@@ -738,7 +846,8 @@ util::geo::MultiPoint<double> Requestor::geomPointGeoms(size_t oid,
 
   if (oid > 0) {
     for (size_t i = oid - 1;
-         i < _objects.size() && _objects[i].second == _objects[oid].second; i--) {
+         i < _objects.size() && _objects[i].second == _objects[oid].second;
+         i--) {
       if (_objects[i].first >= I_OFFSET) continue;
       auto p = _cache->getPoints()[_objects[i].first];
       points.push_back({p.getX(), p.getY()});
@@ -756,27 +865,63 @@ util::geo::MultiPolygon<double> Requestor::geomPolyGeoms(size_t oid,
   // catch multigeometries
   for (size_t i = oid;
        i < _objects.size() && _objects[i].second == _objects[oid].second; i++) {
-    if (_objects[i].first < I_OFFSET || !Requestor::isArea(_objects[i].first - I_OFFSET)) continue;
+    if (_objects[i].first < I_OFFSET ||
+        !Requestor::isArea(_objects[i].first - I_OFFSET))
+      continue;
     const auto& dline = extractLineGeom(_objects[i].first - I_OFFSET);
     polys.push_back(util::geo::DPolygon(util::geo::simplify(dline, eps)));
   }
 
   if (oid > 0) {
-  for (size_t i = oid - 1;
-       i < _objects.size() && _objects[i].second == _objects[oid].second; i--) {
-    if (_objects[i].first < I_OFFSET || !Requestor::isArea(_objects[i].first - I_OFFSET)) continue;
-    const auto& dline = extractLineGeom(_objects[i].first - I_OFFSET);
-    polys.push_back(util::geo::DPolygon(util::geo::simplify(dline, eps)));
+    for (size_t i = oid - 1;
+         i < _objects.size() && _objects[i].second == _objects[oid].second;
+         i--) {
+      if (_objects[i].first < I_OFFSET ||
+          !Requestor::isArea(_objects[i].first - I_OFFSET))
+        continue;
+      const auto& dline = extractLineGeom(_objects[i].first - I_OFFSET);
+      polys.push_back(util::geo::DPolygon(util::geo::simplify(dline, eps)));
+    }
   }
-}
 
   return polys;
 }
 
 // _____________________________________________________________________________
+std::vector<std::pair<util::geo::FPoint, ID_TYPE>> Requestor::getDynamicPoints(
+    const std::vector<IdMapping>& ids) const {
+  std::vector<std::pair<util::geo::FPoint, ID_TYPE>> ret;
+
+  for (const auto& p : ids) {
+    uint8_t type = (p.qid & (uint64_t(15) << 60)) >> 60;
+    if (type != 8) continue;  // 8 = Geopoint in Qlever
+
+    uint64_t maskLat = 1073741823;
+    uint64_t maskLng = static_cast<uint64_t>(1073741823) << 30;
+
+    auto lat =
+        ((static_cast<double>((p.qid & maskLat)) / maskLat) * 2 * 180.0) -
+        180.0;
+    auto lng =
+        ((static_cast<double>((p.qid & maskLng) >> 30) / maskLat) * 2 * 90.0) -
+        90.0;
+
+    ret.push_back(
+        {util::geo::latLngToWebMerc(util::geo::FPoint{lat, lng}), p.id});
+  }
+
+  return ret;
+}
+
+// _____________________________________________________________________________
 util::geo::DPoint Requestor::clusterGeom(size_t cid, double res) const {
   size_t oid = _clusterObjects[cid].first;
-  const auto& pp = _cache->getPoints()[_objects[oid].first];
+
+  util::geo::FPoint pp;
+  if (oid > _objects.size())
+    pp = _dynamicPoints[oid - _objects.size()].first;
+  else
+    pp = getPoint(_objects[oid].first);
 
   if (res < 0) return {pp.getX(), pp.getY()};
 

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -68,6 +68,7 @@ void Requestor::request(const std::string& qry) {
 
   // dynamic points present in query
   _dynamicPoints = getDynamicPoints(reader._ids);
+  _numObjects += _dynamicPoints.size();
 
   LOG(INFO) << "[REQUESTOR] ... done, got "
             << _objects.size() + _dynamicPoints.size() << " objects.";

--- a/src/qlever-petrimaps/server/Requestor.h
+++ b/src/qlever-petrimaps/server/Requestor.h
@@ -70,12 +70,21 @@ class Requestor {
     return _objects;
   }
 
-  const std::vector<std::pair<ID_TYPE, std::pair<size_t, size_t>>>& getClusters() const {
+  const std::vector<std::pair<util::geo::FPoint, ID_TYPE>>& getDynamicPoints() const {
+    return _dynamicPoints;
+  }
+
+  const std::vector<std::pair<ID_TYPE, std::pair<size_t, size_t>>>&
+  getClusters() const {
     return _clusterObjects;
   }
 
   const util::geo::FPoint& getPoint(ID_TYPE id) const {
     return _cache->getPoints()[id];
+  }
+
+  const util::geo::FPoint& getDPoint(ID_TYPE id) const {
+    return _dynamicPoints[id].first;
   }
 
   size_t getLine(ID_TYPE id) const { return _cache->getLine(id); }
@@ -90,7 +99,8 @@ class Requestor {
     return _cache->getLineBBox(id);
   }
 
-  const ResObj getNearest(util::geo::DPoint p, double rad, double res, util::geo::FBox box) const;
+  const ResObj getNearest(util::geo::DPoint p, double rad, double res,
+                          util::geo::FBox box) const;
 
   const ResObj getGeom(size_t id, double rad) const;
 
@@ -126,11 +136,15 @@ class Requestor {
   std::string prepQuery(std::string query) const;
   std::string prepQueryRow(std::string query, uint64_t row) const;
 
+  std::vector<std::pair<util::geo::FPoint, ID_TYPE>> getDynamicPoints(
+      const std::vector<IdMapping>& ids) const;
+
   std::string _query;
 
   mutable std::mutex _m;
 
   std::vector<std::pair<ID_TYPE, ID_TYPE>> _objects;
+  std::vector<std::pair<util::geo::FPoint, ID_TYPE>> _dynamicPoints;
   std::vector<std::pair<ID_TYPE, std::pair<size_t, size_t>>> _clusterObjects;
   size_t _numObjects = 0;
 

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -816,8 +816,7 @@ util::http::Answer Server::handleQueryReq(const Params& pars) const {
 
   {
     std::lock_guard<std::mutex> guard(_m);
-    if (util::toLower(query).find("rand()") == std::string::npos &&
-        _queryCache.count(queryId)) {
+    if (_queryCache.count(queryId)) {
       sessionId = _queryCache[queryId];
       reqor = _rs[sessionId];
     } else {
@@ -827,7 +826,8 @@ util::http::Answer Server::handleQueryReq(const Params& pars) const {
       sessionId = getSessionId();
 
       _rs[sessionId] = reqor;
-      _queryCache[queryId] = sessionId;
+      if (util::toLower(query).find("rand()") == std::string::npos)
+        _queryCache[queryId] = sessionId;
     }
   }
 

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -209,6 +209,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   // initialize vectors to 0
   for (size_t i = 0; i < NUM_THREADS; i++) points2[i].resize(w * h, 0);
 
+  // POINTS
   if (intersects(r->getPointGrid().getBBox(), fbbox)) {
     LOG(INFO) << "[SERVER] Looking up display points...";
     if (res < THRESHOLD) {
@@ -221,10 +222,17 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
         size_t i = ret[j];
 
         const auto& objs = r->getObjects();
+        const auto& dynPoints = r->getDynamicPoints();
 
-        if (i >= objs.size() && style == OBJECTS) {
-          size_t cid = i - objs.size();
-          const auto& p = r->getPoint(objs[r->getClusters()[cid].first].first);
+        if (i >= objs.size() + dynPoints.size() && style == OBJECTS) {
+          size_t cid = i - objs.size() - dynPoints.size();
+          FPoint p;
+          size_t oid = r->getClusters()[cid].first;
+
+          if (oid >= objs.size())
+            p = dynPoints[oid - objs.size()].first;
+          else
+            p = r->getPoint(objs[oid].first);
 
           if (!contains(p, fbbox)) continue;
 
@@ -239,8 +247,15 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
           drawPoint(points[0], points2[0], px, py, w, h, style, 1);
           drawLine(image.data(), ppx, ppy, px, py, w, h);
         } else {
-          if (i >= objs.size()) i = r->getClusters()[i - objs.size()].first;
-          const auto& p = r->getPoint(objs[i].first);
+          if (i >= objs.size() + dynPoints.size())
+            i = r->getClusters()[i - objs.size() - dynPoints.size()].first;
+
+          FPoint p;
+          if (i < objs.size())
+            p = r->getPoint(objs[i].first);
+          else
+            p = r->getDPoint(i - objs.size());
+
           if (!contains(p, fbbox)) continue;
 
           int px = ((p.getX() - bbox.getLowerLeft().getX()) / mercW) * w;
@@ -283,12 +298,17 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
                       cell->size());
           } else {
             for (auto i : *cell) {
-              if (i >= r->getObjects().size()) {
-                assert(i - r->getObjects().size() < r->getClusters().size());
-                i = r->getClusters()[i - r->getObjects().size()].first;
+              if (i >= r->getObjects().size() + r->getDynamicPoints().size()) {
+                i = r->getClusters()[i - r->getObjects().size() -
+                                     r->getDynamicPoints().size()]
+                        .first;
               }
-              assert(i < r->getObjects().size());
-              const auto& p = r->getPoint(r->getObjects()[i].first);
+
+              FPoint p;
+              if (i < r->getObjects().size())
+                p = r->getPoint(r->getObjects()[i].first);
+              else
+                p = r->getDPoint(i - r->getObjects().size());
 
               int px = ((p.getX() - bbox.getLowerLeft().getX()) / mercW) * w;
               int py =
@@ -535,7 +555,7 @@ util::http::Answer Server::handleGeoJSONReq(const Params& pars) const {
 
   if (pars.count("gid") == 0 || pars.find("gid")->second.empty())
     throw std::invalid_argument("No geom id (?gid=) specified.");
-  auto gid = std::atoi(pars.find("gid")->second.c_str());
+  size_t gid = std::atoi(pars.find("gid")->second.c_str());
 
   bool noExport = pars.count("export") == 0 ||
                   pars.find("export")->second.empty() ||
@@ -564,7 +584,13 @@ util::http::Answer Server::handleGeoJSONReq(const Params& pars) const {
   util::json::Val dict;
 
   if (!noExport) {
-    for (auto col : reqor->requestRow(reqor->getObjects()[gid].second)) {
+    size_t row;
+    if (gid < reqor->getObjects().size())
+      row = reqor->getObjects()[gid].second;
+    else
+      row = reqor->getDynamicPoints()[gid].second;
+
+    for (auto col : reqor->requestRow(row)) {
       dict.dict[col.first] = col.second;
     }
   }

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -816,7 +816,8 @@ util::http::Answer Server::handleQueryReq(const Params& pars) const {
 
   {
     std::lock_guard<std::mutex> guard(_m);
-    if (_queryCache.count(queryId)) {
+    if (util::toLower(query).find("rand()") == std::string::npos &&
+        _queryCache.count(queryId)) {
       sessionId = _queryCache[queryId];
       reqor = _rs[sessionId];
     } else {

--- a/web/script.js
+++ b/web/script.js
@@ -263,7 +263,7 @@ function updateLoad(stage, percent, totalProgress, currentProgress) {
         case 3:
             infoHeadingElem.innerHTML = "Reading cached geometries from disk";
             infoDescElem.innerHTML = "This needs to be done only once after the server has been started and does not have to be repeated for subsequent queries.";
-            stageElem.innerHTML = `Reading ${currentProgress}/${totalProgress} geometries from disk... (1/1)`;
+            stageElem.innerHTML = `Reading ${currentProgress}/${totalProgress} objects from disk... (1/1)`;
             document.getElementById("load-status").style.display = "grid";
             break;
         case 4:


### PR DESCRIPTION
With this PR, petrimaps does not fill the geometry cache with `POINT` geometries any more. These are now folded into the internal IDs in QLever, and petrimaps reads them dynamically from the query result.

We also try to avoid caching of queries with non-deterministic results by skipping caching altogether if `rand()` is present in the lowercased query.