### PR TITLE
More standard-compliant parsing of WKT literals

### DIFF
--- a/src/qlever-petrimaps/CMakeLists.txt
+++ b/src/qlever-petrimaps/CMakeLists.txt
@@ -39,4 +39,4 @@ add_custom_target(htmlfiles DEPENDS index.h build.h style.h)
 
 add_dependencies(qlever_petrimaps_dep htmlfiles)
 
-target_link_libraries(petrimaps qlever_petrimaps_dep 3rdparty_dep util ${PNG_LIBRARIES} -lpthread -lcurl)
+target_link_libraries(petrimaps qlever_petrimaps_dep 3rdparty_dep pb_util ${PNG_LIBRARIES} -lpthread -lcurl)

--- a/src/qlever-petrimaps/GeomCache.h
+++ b/src/qlever-petrimaps/GeomCache.h
@@ -127,9 +127,6 @@ class GeomCache {
 
   std::string queryUrl(std::string query, size_t offset, size_t limit) const;
 
-  util::geo::FPoint createPoint(const std::string& a, size_t p) const;
-
-  static bool pointValid(const util::geo::FPoint& p);
   static bool pointValid(const util::geo::DPoint& p);
 
   static util::geo::DLine createLineString(const std::string& a, size_t p);

--- a/src/qlever-petrimaps/GeomCache.h
+++ b/src/qlever-petrimaps/GeomCache.h
@@ -134,17 +134,21 @@ class GeomCache {
 
   static util::geo::DLine createLineString(const std::string& a, size_t p);
 
-	size_t parsePolygon(const std::string& str, size_t p, size_t end, size_t* i);
-
-	size_t parseMultiPoint(const std::string &str, size_t p, size_t end, size_t* i);
-	size_t parseMultiLineString(const std::string &str, size_t p, size_t end, size_t* i);
-  size_t parseMultiPolygon(const std::string &str, size_t p, size_t end, size_t* i);
+	void addPolygon(const util::geo::Polygon<double>& p, size_t* i);
+	void addMultiPoint(const util::geo::MultiPoint<double>& mp, size_t *i);
+	void addMultiLineString(const util::geo::MultiLine<double>& ml, size_t* i);
+	void addLineString(const util::geo::Line<double>& l, size_t* i);
+  void addMultiPolygon(const util::geo::MultiPolygon<double>& mp, size_t* i);
 
   void insertLine(const util::geo::DLine& l, bool isArea);
 
 	static std::vector<size_t> getGeomStarts(const std::string &str, size_t a);
 
   std::string indexHashFromDisk(const std::string& fname);
+
+  static util::geo::DPoint projD(const util::geo::DPoint& p) {
+    return util::geo::latLngToWebMerc<double>(p);
+  }
 
   std::vector<util::geo::FPoint> _points;
   std::vector<util::geo::Point<int16_t>> _linePoints;

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -12,6 +12,9 @@
 #include "util/log/Log.h"
 
 using petrimaps::RequestReader;
+using util::LogLevel::INFO;
+using util::LogLevel::ERROR;
+using util::LogLevel::WARN;
 
 // _____________________________________________________________________________
 std::vector<std::string> RequestReader::requestColumns(const std::string& query) {

--- a/src/qlever-petrimaps/PetriMapsMain.cpp
+++ b/src/qlever-petrimaps/PetriMapsMain.cpp
@@ -12,6 +12,9 @@
 #include "util/log/Log.h"
 
 using petrimaps::Server;
+using util::LogLevel::INFO;
+using util::LogLevel::ERROR;
+using util::LogLevel::WARN;
 
 // _____________________________________________________________________________
 void printHelp(int argc, char** argv) {

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -24,6 +24,9 @@ using petrimaps::GeomCache;
 using petrimaps::Requestor;
 using petrimaps::RequestReader;
 using petrimaps::ResObj;
+using util::LogLevel::INFO;
+using util::LogLevel::ERROR;
+using util::LogLevel::WARN;
 
 // _____________________________________________________________________________
 void Requestor::request(const std::string& qry) {


### PR DESCRIPTION
So far, parsing of WKT literals happened at three difference places in our various codebases: here in https://github.com/ad-freiburg/qlever-petrimaps, in https://github.com/ad-freiburg/spatialjoin, and in the https://github.com/ad-freiburg/util library, which is used by both `qlever-petrimaps` and `spatialjoin`.

With https://github.com/ad-freiburg/util/commit/36ddced1a2f86294850f4c9dd433d26720f534d1, the (very fast) WKT parsing code used in `spatialjoin` was migrated to the `util` library. With https://github.com/ad-freiburg/spatialjoin/commit/a722f0a98ff777fa947c12bfc553fb569372598c, this is used in `spatialjoin`. This PR drops all WKT parsing from `qlever-petrimaps` and also uses the WKT parsing code from `util`. This has the following effects:

* We now support arbitrary padding of WKT geometries with whitespace and/or quotation marks
* We no longer require uppercase letters in WKT (`LINESTRING` is supported, as is `Linestring` or `linestring` or `liNeStriNg`)
* We allow arbitrary additional whitespace (checked via `std::is_space`) everywhere
* We ignore all characters after the geometry identifier until the opening bracket; for example, `LINESTRING Z (...)` or `LINESTRING MZ (...)` or `LINESTRING M (...)` or `LINESTRING FOOBAR (...)` are now handled just like `LINESTRING`; note, however, that we still only support 2D coordinates and any additional dimension will be ignored; for example, `LINESTRING M(0 0 1, 1 1 2)` will has the same effect as `LINESTRING(0 0, 1 1)`
* We allow geometry types to be prefixed with `M` (although this does not follow the standard, measured geometries are sometimes given as `MLINESTRING` instead of `LINESTRING M`) 

In particular, fixes #24 and #25