### PR TITLE
Bump workflow builds to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Build
 'on':
   - push
 jobs:
-  ubuntu-20-04-build-gcc:
-    runs-on: ubuntu-20.04
+  ubuntu-22-04-build-gcc:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v2
@@ -32,8 +32,8 @@ jobs:
         run: mkdir build && cd build && cmake ..
       - name: make
         run: cd build && make
-  ubuntu-20-04-build-clang:
-    runs-on: ubuntu-20.04
+  ubuntu-22-04-build-clang:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
The Ubuntu 20.04 LTS runner is no longer supported since 15.04.2025, see https://github.com/actions/runner-images/issues/11101