### PR TITLE
Prepare for packaging with CPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ add_subdirectory(src)
 install(
   TARGETS qlever-petrimaps DESTINATION bin
   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-              GROUP_READ GROUP_WRITE GROUP_EXECUTE
+              GROUP_READ GROUP_EXECUTE
               WORLD_READ WORLD_EXECUTE
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ add_subdirectory(src)
 
 # install target
 install(
-  TARGETS petrimaps DESTINATION bin
+  TARGETS qlever-petrimaps DESTINATION bin
   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
               GROUP_READ GROUP_WRITE GROUP_EXECUTE
               WORLD_READ WORLD_EXECUTE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,65 @@ add_subdirectory(src)
 
 # install target
 install(
-  FILES ${CMAKE_BINARY_DIR}/petrimaps DESTINATION bin
-  PERMISSIONS OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE
+  TARGETS petrimaps DESTINATION bin
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+              GROUP_READ GROUP_WRITE GROUP_EXECUTE
+              WORLD_READ WORLD_EXECUTE
 )
+
+###############################################################
+# CPack packaging
+###############################################################
+
+set(CPACK_PACKAGE_NAME "qlever-petrimaps")
+set(CPACK_PACKAGE_VERSION "0.5.45")
+
+# Debian package revision number (e.g., the "1" in "0.5.42-1~plucky~25.04").
+# Override with: cmake -DPACKAGE_REVISION=2
+set(PACKAGE_REVISION "1" CACHE STRING "Debian package revision number")
+
+# Version suffix for distribution-specific packages (e.g., "~plucky~25.04").
+# Auto-detected from /etc/os-release for Ubuntu and Debian.
+# For derived distros, override with: cmake -DVERSION_SUFFIX="~noble~24.04"
+set(DEFAULT_VERSION_SUFFIX "")
+if (EXISTS "/etc/os-release")
+    file(STRINGS "/etc/os-release" OS_RELEASE_CONTENTS)
+
+    set(_OS_ID "")
+    set(_OS_VERSION_ID "")
+    set(_OS_VERSION_CODENAME "")
+
+    foreach(line ${OS_RELEASE_CONTENTS})
+        if (line MATCHES "^ID=\"?([^\"]*)\"?$")
+            set(_OS_ID "${CMAKE_MATCH_1}")
+        elseif (line MATCHES "^VERSION_ID=\"?([^\"]*)\"?$")
+            set(_OS_VERSION_ID "${CMAKE_MATCH_1}")
+        elseif (line MATCHES "^VERSION_CODENAME=\"?([^\"]*)\"?$")
+            set(_OS_VERSION_CODENAME "${CMAKE_MATCH_1}")
+        endif()
+    endforeach()
+
+    if (_OS_VERSION_CODENAME AND _OS_VERSION_ID)
+        if (_OS_ID STREQUAL "ubuntu")
+            set(DEFAULT_VERSION_SUFFIX "~${_OS_VERSION_CODENAME}~${_OS_VERSION_ID}")
+        elseif (_OS_ID STREQUAL "debian")
+            set(DEFAULT_VERSION_SUFFIX "~${_OS_VERSION_CODENAME}~deb${_OS_VERSION_ID}")
+        endif()
+    endif()
+endif()
+
+set(VERSION_SUFFIX "${DEFAULT_VERSION_SUFFIX}" CACHE STRING "Distribution-specific version suffix")
+
+set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION}-${PACKAGE_REVISION}${VERSION_SUFFIX}")
+
+set(CPACK_PACKAGE_CONTACT "mundhahj@tf.uni-freiburg.de")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/ad-freiburg/qlever-petrimaps")
+
+set(CPACK_OUTPUT_FILE_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/packages")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+
+set(CPACK_VERBATIM_VARIABLES YES)
+
+include(CPack)

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /
 RUN apt update && apt install -y --no-install-recommends ca-certificates xxd libgomp1 libpng-dev libcurl4-gnutls-dev dumb-init && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /build/petrimaps /petrimaps
+COPY --from=builder /build/qlever-petrimaps /qlever-petrimaps
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/petrimaps"]
+CMD ["/qlever-petrimaps"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ via Docker:
 
 To start:
 
-    $ petrimaps [-p <port=9090>] [-m <memory limit] [-c <cache dir>]
+    $ qlever-petrimaps [-p <port=9090>] [-m <memory limit] [-c <cache dir>]
 
 Requests can be send via the `?query` get parameter.
 The QLever backend to use must be specified via the `?backend` get parameter.

--- a/src/qlever-petrimaps/CMakeLists.txt
+++ b/src/qlever-petrimaps/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories(
 	${PNG_INCLUDE_DIRS}_
 )
 
-add_executable(petrimaps ${qlever_petrimaps_main})
+add_executable(qlever-petrimaps ${qlever_petrimaps_main})
 add_library(qlever_petrimaps_dep ${QLEVER_PETRIMAPS_SRC})
 
 add_custom_command(
@@ -39,4 +39,4 @@ add_custom_target(htmlfiles DEPENDS index.h build.h style.h)
 
 add_dependencies(qlever_petrimaps_dep htmlfiles)
 
-target_link_libraries(petrimaps qlever_petrimaps_dep 3rdparty_dep pb_util pb_util_geo pb_util_json pb_util_http ${PNG_LIBRARIES} -lpthread -lcurl)
+target_link_libraries(qlever-petrimaps qlever_petrimaps_dep 3rdparty_dep pb_util pb_util_geo pb_util_json pb_util_http ${PNG_LIBRARIES} -lpthread -lcurl)


### PR DESCRIPTION
- Basic packaging using CPack very similar to QLever's setup. The version  can also be taken automatically from tags once those are present.
- Renamed main binary to `qlever-petrimaps` for consistency.