### PR TITLE
`X-Real-IP` headers in HTTP requests to QLever, for better rate limiting

### DIFF
--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -55,49 +55,6 @@ std::string GeomCache::getCountQuery() const {
 }
 
 // _____________________________________________________________________________
-size_t GeomCache::writeCb(void *contents, size_t size, size_t nmemb,
-                          void *userp) {
-  size_t realsize = size * nmemb;
-
-  try {
-    static_cast<GeomCache *>(userp)->parse(static_cast<const char *>(contents),
-                                           realsize);
-  } catch (...) {
-    static_cast<GeomCache *>(userp)->_exceptionPtr = std::current_exception();
-    return CURLE_WRITE_ERROR;
-  }
-  return realsize;
-}
-
-// _____________________________________________________________________________
-size_t GeomCache::writeCbIds(void *contents, size_t size, size_t nmemb,
-                             void *userp) {
-  size_t realsize = size * nmemb;
-  try {
-    static_cast<GeomCache *>(userp)->parseIds(
-        static_cast<const char *>(contents), realsize);
-  } catch (...) {
-    static_cast<GeomCache *>(userp)->_exceptionPtr = std::current_exception();
-    return CURLE_WRITE_ERROR;
-  }
-  return realsize;
-}
-
-// _____________________________________________________________________________
-size_t GeomCache::writeCbCount(void *contents, size_t size, size_t nmemb,
-                               void *userp) {
-  size_t realsize = size * nmemb;
-  try {
-    static_cast<GeomCache *>(userp)->parseCount(
-        static_cast<const char *>(contents), realsize);
-  } catch (...) {
-    static_cast<GeomCache *>(userp)->_exceptionPtr = std::current_exception();
-    return CURLE_WRITE_ERROR;
-  }
-  return realsize;
-}
-
-// _____________________________________________________________________________
 void GeomCache::parse(const char *c, size_t size) {
   _loadStatusStage = _LoadStatusStages::Parse;
 
@@ -350,9 +307,9 @@ size_t GeomCache::requestSize() {
   auto flds = queryFields(countQuery, 0, 1);
 
   try {
-    performCurlRequest(_curl, _config.backend, flds,
-                       "text/tab-separated-values", GeomCache::writeCbCount,
-                       this, &_raw, &_exceptionPtr);
+    performCurlRequest(
+        _config.backend, flds, "text/tab-separated-values",
+        [this](const char *c, size_t n) { parseCount(c, n); }, &_raw);
   } catch (const std::exception &e) {
     LOG(ERROR) << "[GEOMCACHE] Count query failed: " << e.what();
     return 0;
@@ -375,8 +332,9 @@ void GeomCache::requestPart(size_t offset) {
   _lastBytesReceived = 0;
 
   auto flds = queryFields(getFillQuery(), offset, 10000000);
-  performCurlRequest(_curl, _config.backend, flds, "text/tab-separated-values",
-                     GeomCache::writeCb, this, &_raw, &_exceptionPtr);
+  performCurlRequest(
+      _config.backend, flds, "text/tab-separated-values",
+      [this](const char *c, size_t n) { parse(c, n); }, &_raw);
 }
 
 // _____________________________________________________________________________
@@ -511,7 +469,6 @@ void GeomCache::requestIds() {
   _curUniqueGeom = 0;
   _maxQid = 0;
   _lastQid = -1;
-  _exceptionPtr = 0;
 
   LOG(INFO) << "[GEOMCACHE] Query is " << getFillQuery();
 
@@ -541,8 +498,9 @@ void GeomCache::requestIds() {
 // _____________________________________________________________________________
 void GeomCache::requestIdPart(size_t offset) {
   auto flds = queryFields(getFillQuery(), offset, 100000000);
-  performCurlRequest(_curl, _config.backend, flds, "application/octet-stream",
-                     GeomCache::writeCbIds, this, &_raw, &_exceptionPtr);
+  performCurlRequest(
+      _config.backend, flds, "application/octet-stream",
+      [this](const char *c, size_t n) { parseIds(c, n); }, &_raw);
 }
 
 // _____________________________________________________________________________
@@ -558,11 +516,14 @@ std::string GeomCache::queryFields(std::string query, size_t offset,
     query += " OFFSET " + std::to_string(offset);
   }
 
-  auto esc = curl_easy_escape(_curl, query.c_str(), query.size());
+  // TODO: dont spin up an entire CURL instance here, is this necessary?
+  CURL *curl = curl_easy_init();
+  auto esc = curl_easy_escape(curl, query.c_str(), query.size());
 
   ss << "send=" << std::to_string(MAXROWS) << "&query=" << esc;
 
   curl_free(esc);
+  curl_easy_cleanup(curl);
 
   return ss.str();
 }

--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -308,7 +308,7 @@ size_t GeomCache::requestSize() {
 
   try {
     performCurlRequest(
-        _config.backend, flds, "text/tab-separated-values",
+        _config.backend, flds, "text/tab-separated-values", "",
         [this](const char *c, size_t n) { parseCount(c, n); }, &_raw);
   } catch (const std::exception &e) {
     LOG(ERROR) << "[GEOMCACHE] Count query failed: " << e.what();
@@ -333,7 +333,7 @@ void GeomCache::requestPart(size_t offset) {
 
   auto flds = queryFields(getFillQuery(), offset, 10000000);
   performCurlRequest(
-      _config.backend, flds, "text/tab-separated-values",
+      _config.backend, flds, "text/tab-separated-values", "",
       [this](const char *c, size_t n) { parse(c, n); }, &_raw);
 }
 
@@ -499,7 +499,7 @@ void GeomCache::requestIds() {
 void GeomCache::requestIdPart(size_t offset) {
   auto flds = queryFields(getFillQuery(), offset, 100000000);
   performCurlRequest(
-      _config.backend, flds, "application/octet-stream",
+      _config.backend, flds, "application/octet-stream", "",
       [this](const char *c, size_t n) { parseIds(c, n); }, &_raw);
 }
 
@@ -1080,7 +1080,7 @@ void GeomCache::serializeToDisk(const std::string &fname) const {
 void GeomCache::requestRasterMeta() {
   auto r = RequestReader(getConfig().backend, _maxMemory, 0, 0, 0);
 
-  _rasterMeta = r.requestRasterMeta(getConfig().rasterMetaQuery);
+  _rasterMeta = r.requestRasterMeta(getConfig().rasterMetaQuery, "");
 
   for (const auto &rm : _rasterMeta) {
     LOG(INFO) << "Configured raster " << rm.first << ": " << rm.second.first

--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -343,56 +343,18 @@ size_t GeomCache::requestSize() {
   _raw.clear();
   _raw.reserve(1000);
 
-  CURLcode res;
-  char errbuf[CURL_ERROR_SIZE];
+  const std::string &countQuery = getCountQuery();
+  LOG(INFO) << "[GEOMCACHE] Count query to obtain the number of geometries:"
+            << std::endl
+            << countQuery;
+  auto flds = queryFields(countQuery, 0, 1);
 
-  if (_curl) {
-    const std::string &countQuery = getCountQuery();
-    LOG(INFO) << "[GEOMCACHE] Count query to obtain the number of geometries:"
-              << std::endl
-              << countQuery;
-    auto flds = queryFields(countQuery, 0, 1);
-    petrimapsCurlSetup(_curl);
-    curl_easy_setopt(_curl, CURLOPT_URL, _config.backend.c_str());
-    curl_easy_setopt(_curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(_curl, CURLOPT_POSTFIELDS, flds.c_str());
-    curl_easy_setopt(_curl, CURLOPT_WRITEFUNCTION, GeomCache::writeCbCount);
-    curl_easy_setopt(_curl, CURLOPT_WRITEDATA, this);
-    curl_easy_setopt(_curl, CURLOPT_ERRORBUFFER, errbuf);
-
-    // set headers
-    struct curl_slist *headers = 0;
-    headers = curl_slist_append(headers, "Accept: text/tab-separated-values");
-    curl_easy_setopt(_curl, CURLOPT_HTTPHEADER, headers);
-
-    res = curl_easy_perform(_curl);
-
-    long httpCode = 0;
-    curl_easy_getinfo(_curl, CURLINFO_RESPONSE_CODE, &httpCode);
-
-    curl_slist_free_all(headers);
-
-    if (httpCode != 200) {
-      std::stringstream ss;
-      LOG(ERROR) << "[GEOMCACHE] QLever backend returned status code "
-                 << httpCode << " during count query";
-      return 0;
-    }
-
-    if (_exceptionPtr) std::rethrow_exception(_exceptionPtr);
-  } else {
-    LOG(ERROR) << "[GEOMCACHE] Failed to perform curl request.";
-    return 0;
-  }
-
-  // check if there was an error
-  if (res != CURLE_OK) {
-    size_t len = strlen(errbuf);
-    if (len > 0) {
-      LOG(ERROR) << "[GEOMCACHE] " << errbuf;
-    } else {
-      LOG(ERROR) << "[GEOMCACHE] " << curl_easy_strerror(res);
-    }
+  try {
+    performCurlRequest(_curl, _config.backend, flds,
+                       "text/tab-separated-values", GeomCache::writeCbCount,
+                       this, &_raw, &_exceptionPtr);
+  } catch (const std::exception &e) {
+    LOG(ERROR) << "[GEOMCACHE] Count query failed: " << e.what();
     return 0;
   }
 
@@ -412,57 +374,9 @@ void GeomCache::requestPart(size_t offset) {
   _lastReceivedTime = TIME();
   _lastBytesReceived = 0;
 
-  CURLcode res;
-  char errbuf[CURL_ERROR_SIZE];
-
-  if (_curl) {
-    auto flds = queryFields(getFillQuery(), offset, 10000000);
-    petrimapsCurlSetup(_curl);
-    curl_easy_setopt(_curl, CURLOPT_URL, _config.backend.c_str());
-    curl_easy_setopt(_curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(_curl, CURLOPT_POSTFIELDS, flds.c_str());
-    curl_easy_setopt(_curl, CURLOPT_WRITEFUNCTION, GeomCache::writeCb);
-    curl_easy_setopt(_curl, CURLOPT_WRITEDATA, this);
-    curl_easy_setopt(_curl, CURLOPT_ERRORBUFFER, errbuf);
-
-    // set headers
-    struct curl_slist *headers = 0;
-    headers = curl_slist_append(headers, "Accept: text/tab-separated-values");
-    curl_easy_setopt(_curl, CURLOPT_HTTPHEADER, headers);
-
-    // accept any compression supported
-    curl_easy_setopt(_curl, CURLOPT_ACCEPT_ENCODING, "");
-    res = curl_easy_perform(_curl);
-
-    long httpCode = 0;
-    curl_easy_getinfo(_curl, CURLINFO_RESPONSE_CODE, &httpCode);
-
-    curl_slist_free_all(headers);
-
-    if (httpCode != 200) {
-      std::stringstream ss;
-      ss << "QLever backend returned status code " << httpCode
-         << " during query (offset=" << offset << ")";
-      ss << "\n";
-      ss << _raw;
-      throw std::runtime_error(ss.str());
-    }
-
-    if (_exceptionPtr) std::rethrow_exception(_exceptionPtr);
-  } else {
-    LOG(ERROR) << "[GEOMCACHE] Failed to perform curl request.";
-    return;
-  }
-
-  // check if there was an error
-  if (res != CURLE_OK) {
-    size_t len = strlen(errbuf);
-    if (len > 0) {
-      LOG(ERROR) << "[GEOMCACHE] " << errbuf;
-    } else {
-      LOG(ERROR) << "[GEOMCACHE] " << curl_easy_strerror(res);
-    }
-  }
+  auto flds = queryFields(getFillQuery(), offset, 10000000);
+  performCurlRequest(_curl, _config.backend, flds, "text/tab-separated-values",
+                     GeomCache::writeCb, this, &_raw, &_exceptionPtr);
 }
 
 // _____________________________________________________________________________
@@ -626,54 +540,9 @@ void GeomCache::requestIds() {
 
 // _____________________________________________________________________________
 void GeomCache::requestIdPart(size_t offset) {
-  CURLcode res;
-  char errbuf[CURL_ERROR_SIZE];
-
-  if (_curl) {
-    auto flds = queryFields(getFillQuery(), offset, 100000000);
-    petrimapsCurlSetup(_curl);
-    curl_easy_setopt(_curl, CURLOPT_URL, _config.backend.c_str());
-    curl_easy_setopt(_curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(_curl, CURLOPT_POSTFIELDS, flds.c_str());
-    curl_easy_setopt(_curl, CURLOPT_WRITEFUNCTION, GeomCache::writeCbIds);
-    curl_easy_setopt(_curl, CURLOPT_WRITEDATA, this);
-    curl_easy_setopt(_curl, CURLOPT_ERRORBUFFER, errbuf);
-
-    // set headers
-    struct curl_slist *headers = 0;
-    headers = curl_slist_append(headers, "Accept: application/octet-stream");
-    curl_easy_setopt(_curl, CURLOPT_HTTPHEADER, headers);
-
-    res = curl_easy_perform(_curl);
-
-    long httpCode = 0;
-    curl_easy_getinfo(_curl, CURLINFO_RESPONSE_CODE, &httpCode);
-
-    curl_slist_free_all(headers);
-
-    if (httpCode != 200) {
-      std::stringstream ss;
-      ss << "QLever backend returned status code " << httpCode;
-      ss << "\n";
-      ss << _raw;
-      throw std::runtime_error(ss.str());
-    }
-
-    if (_exceptionPtr) std::rethrow_exception(_exceptionPtr);
-  } else {
-    LOG(ERROR) << "[GEOMCACHE] Failed to perform curl request.";
-    return;
-  }
-
-  // check if there was an error
-  if (res != CURLE_OK) {
-    size_t len = strlen(errbuf);
-    if (len > 0) {
-      LOG(ERROR) << "[GEOMCACHE] " << errbuf;
-    } else {
-      LOG(ERROR) << "[GEOMCACHE] " << curl_easy_strerror(res);
-    }
-  }
+  auto flds = queryFields(getFillQuery(), offset, 100000000);
+  performCurlRequest(_curl, _config.backend, flds, "application/octet-stream",
+                     GeomCache::writeCbIds, this, &_raw, &_exceptionPtr);
 }
 
 // _____________________________________________________________________________

--- a/src/qlever-petrimaps/GeomCache.h
+++ b/src/qlever-petrimaps/GeomCache.h
@@ -94,16 +94,14 @@ inline bool operator!=(const GeomCacheConfig& l, const GeomCacheConfig& r) {
 
 class GeomCache {
  public:
-  GeomCache() : _config(), _curl(0), _curRow(0), _maxMemory(-1) {}
+  GeomCache() : _config(), _curRow(0), _maxMemory(-1) {}
   explicit GeomCache(const GeomCacheConfig& config, size_t maxMemory)
       : _config(config),
-        _curl(curl_easy_init()),
         _curRow(0),
         _maxMemory(maxMemory) {}
 
   GeomCache& operator=(GeomCache&& o) {
     _config = o._config;
-    _curl = curl_easy_init();
     _lines = std::move(o._lines);
     _linePoints = std::move(o._linePoints);
     _points = std::move(o._points);
@@ -111,10 +109,6 @@ class GeomCache {
     _state = o._state;
     return *this;
   };
-
-  ~GeomCache() {
-    if (_curl) curl_easy_cleanup(_curl);
-  }
 
   bool ready() const {
     _m.lock();
@@ -184,7 +178,6 @@ class GeomCache {
 
  private:
   GeomCacheConfig _config;
-  CURL* _curl;
 
   uint8_t _curByte;
   ID _curId;
@@ -197,12 +190,6 @@ class GeomCache {
 
   enum _LoadStatusStages { Parse = 1, ParseIds, FromFile, Finished };
   _LoadStatusStages _loadStatusStage = Parse;
-
-  static size_t writeCb(void* contents, size_t size, size_t nmemb, void* userp);
-  static size_t writeCbIds(void* contents, size_t size, size_t nmemb,
-                           void* userp);
-  static size_t writeCbCount(void* contents, size_t size, size_t nmemb,
-                             void* userp);
 
   // Get the right SPARQL query for the given backend.
   const std::string& getFillQuery() const;
@@ -259,8 +246,6 @@ class GeomCache {
 
   std::string _dangling, _prev, _raw;
   ParseState _state;
-
-  std::exception_ptr _exceptionPtr;
 
   mutable std::mutex _m;
   bool _ready = false;

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -26,7 +26,7 @@ const static std::string INDEX_HASH_PREFIX = "_5_";
 // _____________________________________________________________________________
 void petrimaps::performCurlRequest(
     const std::string& url, const std::string& postFields,
-    const std::string& acceptHeader, const std::string& xForwardHeader,
+    const std::string& acceptHeader, const std::string& xRealIP,
     const std::function<void(const char*, size_t)>& parse,
     const std::string* raw) {
   CURL* curl = curl_easy_init();
@@ -78,10 +78,10 @@ void petrimaps::performCurlRequest(
   if (acceptHeader.size()) {
     headers = curl_slist_append(headers, ("Accept: " + acceptHeader).c_str());
   }
-  if (xForwardHeader.size()) {
-    LOG(INFO) << "[SERVER] Remote address is " << xForwardHeader;
+  if (xRealIP.size()) {
+    LOG(INFO) << "[SERVER] Remote address is " << xRealIP;
     headers = curl_slist_append(headers,
-                                ("X-Real-IP: " + xForwardHeader).c_str());
+                                ("X-Real-IP: " + xRealIP).c_str());
   }
 
   if (headers) curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -79,7 +79,7 @@ void petrimaps::performCurlRequest(
     headers = curl_slist_append(headers, ("Accept: " + acceptHeader).c_str());
   }
   if (xForwardHeader.size()) {
-    LOG(INFO) << "[SERVER] Remote address is " << remoteAddr;
+    LOG(INFO) << "[SERVER] Remote address is " << xForwardHeader;
     headers = curl_slist_append(headers,
                                 ("X-Real-IP: " + xForwardHeader).c_str());
   }

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -21,6 +21,67 @@ using util::LogLevel::WARN;
 const static std::string INDEX_HASH_PREFIX = "_5_";
 
 // _____________________________________________________________________________
+void petrimaps::performCurlRequest(
+    CURL* curl, const std::string& url, const std::string& postFields,
+    const std::string& acceptHeader,
+    size_t (*writeCb)(void*, size_t, size_t, void*), void* writeData,
+    const std::string* raw, std::exception_ptr* exceptionPtr) {
+  if (!curl) {
+    throw std::runtime_error("Failed to perform curl request.");
+  }
+
+  char errbuf[CURL_ERROR_SIZE];
+  errbuf[0] = 0;
+
+  petrimapsCurlSetup(curl);
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  if (postFields.size()) {
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postFields.c_str());
+  }
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCb);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, writeData);
+  curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
+
+  struct curl_slist* headers = 0;
+  if (acceptHeader.size()) {
+    headers = curl_slist_append(headers, ("Accept: " + acceptHeader).c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+  }
+
+  CURLcode res = curl_easy_perform(curl);
+
+  long httpCode = 0;
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+
+  if (headers) curl_slist_free_all(headers);
+
+  if (httpCode != 200) {
+    std::stringstream ss;
+    ss << "QLever backend returned status code " << httpCode;
+    if (raw) ss << "\n" << *raw;
+    throw std::runtime_error(ss.str());
+  }
+
+  // an exception thrown inside the write callback takes precedence over a
+  // generic transport error
+  if (exceptionPtr && *exceptionPtr) std::rethrow_exception(*exceptionPtr);
+
+  if (res != CURLE_OK) {
+    std::stringstream ss;
+    ss << "QLever backend request failed: ";
+    if (strlen(errbuf) > 0) {
+      LOG(ERROR) << "[CURL] " << errbuf;
+      ss << errbuf;
+    } else {
+      LOG(ERROR) << "[CURL] " << curl_easy_strerror(res);
+      ss << curl_easy_strerror(res);
+    }
+    throw std::runtime_error(ss.str());
+  }
+}
+
+// _____________________________________________________________________________
 std::vector<std::string> RequestReader::requestColumns(
     const std::string& query) {
   std::string resString;
@@ -39,127 +100,25 @@ std::vector<std::string> RequestReader::requestColumns(
 
 // _____________________________________________________________________________
 void RequestReader::requestIds(const std::string& query) {
-  CURLcode res;
-  char errbuf[CURL_ERROR_SIZE];
-
   _raw.clear();
   _raw.reserve(10000);
 
-  if (_curl) {
-    auto flds = queryFields(query);
-    petrimapsCurlSetup(_curl);
-    curl_easy_setopt(_curl, CURLOPT_URL, _backendUrl.c_str());
-    curl_easy_setopt(_curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(_curl, CURLOPT_POSTFIELDS, flds.c_str());
-    curl_easy_setopt(_curl, CURLOPT_WRITEFUNCTION, RequestReader::writeCbIds);
-    curl_easy_setopt(_curl, CURLOPT_WRITEDATA, this);
-
-    // set headers
-    struct curl_slist* headers = 0;
-    headers = curl_slist_append(headers, "Accept: application/octet-stream");
-    curl_easy_setopt(_curl, CURLOPT_HTTPHEADER, headers);
-
-    curl_easy_setopt(_curl, CURLOPT_ERRORBUFFER, errbuf);
-    res = curl_easy_perform(_curl);
-
-    long httpCode = 0;
-    curl_easy_getinfo(_curl, CURLINFO_RESPONSE_CODE, &httpCode);
-
-    curl_slist_free_all(headers);
-
-    if (httpCode != 200) {
-      std::stringstream ss;
-      ss << "QLever backend returned status code " << httpCode;
-      ss << "\n";
-      ss << _raw;
-      throw std::runtime_error(ss.str());
-    }
-
-    if (exceptionPtr) std::rethrow_exception(exceptionPtr);
-
-  } else {
-    LOG(ERROR) << "[REQUESTREADER] Failed to perform curl request.";
-    return;
-  }
-
-  if (res != CURLE_OK) {
-    std::stringstream ss;
-    ss << "QLever backend request failed: ";
-    size_t len = strlen(errbuf);
-    if (len > 0) {
-      LOG(ERROR) << "[REQUESTREADER] " << errbuf;
-      ss << errbuf;
-    } else {
-      LOG(ERROR) << "[REQUESTREADER] " << curl_easy_strerror(res);
-      ss << curl_easy_strerror(res);
-    }
-
-    throw std::runtime_error(ss.str());
-  }
+  performCurlRequest(_curl, _backendUrl, queryFields(query),
+                     "application/octet-stream", RequestReader::writeCbIds,
+                     this, &_raw, &exceptionPtr);
 }
 
 // _____________________________________________________________________________
 std::map<size_t, std::pair<double, double>> RequestReader::requestRasterMeta(
     const std::string& query) {
-  CURLcode res;
-  char errbuf[CURL_ERROR_SIZE];
   _curRasterFieldDimensions = {};
 
   _raw.clear();
   _raw.reserve(10000);
 
-  if (_curl) {
-    auto flds = queryFields(query);
-    petrimapsCurlSetup(_curl);
-    curl_easy_setopt(_curl, CURLOPT_URL, _backendUrl.c_str());
-    curl_easy_setopt(_curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(_curl, CURLOPT_POSTFIELDS, flds.c_str());
-    curl_easy_setopt(_curl, CURLOPT_WRITEFUNCTION,
-                     RequestReader::writeCbRasterMeta);
-    curl_easy_setopt(_curl, CURLOPT_WRITEDATA, this);
-
-    // set headers
-    struct curl_slist* headers = 0;
-    headers = curl_slist_append(headers, "Accept: application/octet-stream");
-    curl_easy_setopt(_curl, CURLOPT_HTTPHEADER, headers);
-
-    curl_easy_setopt(_curl, CURLOPT_ERRORBUFFER, errbuf);
-    res = curl_easy_perform(_curl);
-
-    long httpCode = 0;
-    curl_easy_getinfo(_curl, CURLINFO_RESPONSE_CODE, &httpCode);
-
-    curl_slist_free_all(headers);
-
-    if (httpCode != 200) {
-      std::stringstream ss;
-      ss << "QLever backend returned status code " << httpCode;
-      ss << "\n";
-      ss << _raw;
-      throw std::runtime_error(ss.str());
-    }
-
-    if (exceptionPtr) std::rethrow_exception(exceptionPtr);
-
-  } else {
-    LOG(ERROR) << "[REQUESTREADER] Failed to perform curl request.";
-    return {};
-  }
-
-  if (res != CURLE_OK) {
-    std::stringstream ss;
-    ss << "QLever backend request failed: ";
-    size_t len = strlen(errbuf);
-    if (len > 0) {
-      LOG(ERROR) << "[REQUESTREADER] " << errbuf;
-      ss << errbuf;
-    } else {
-      LOG(ERROR) << "[REQUESTREADER] " << curl_easy_strerror(res);
-      ss << curl_easy_strerror(res);
-    }
-
-    throw std::runtime_error(ss.str());
-  }
+  performCurlRequest(
+      _curl, _backendUrl, queryFields(query), "application/octet-stream",
+      RequestReader::writeCbRasterMeta, this, &_raw, &exceptionPtr);
 
   return _curRasterFieldDimensions;
 }
@@ -173,62 +132,12 @@ void RequestReader::requestRows(const std::string& query) {
 void RequestReader::requestRows(const std::string& query,
                                 size_t (*writeCb)(void*, size_t, size_t, void*),
                                 void* ptr) {
-  CURLcode res;
-  char errbuf[CURL_ERROR_SIZE];
-
   _raw.clear();
   _raw.reserve(10000);
 
-  if (_curl) {
-    auto flds = queryFields(query);
-    petrimapsCurlSetup(_curl);
-    curl_easy_setopt(_curl, CURLOPT_URL, _backendUrl.c_str());
-    curl_easy_setopt(_curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(_curl, CURLOPT_POSTFIELDS, flds.c_str());
-    curl_easy_setopt(_curl, CURLOPT_WRITEFUNCTION, writeCb);
-    curl_easy_setopt(_curl, CURLOPT_WRITEDATA, ptr);
-
-    // set headers
-    struct curl_slist* headers = 0;
-    headers = curl_slist_append(headers, "Accept: text/tab-separated-values");
-    curl_easy_setopt(_curl, CURLOPT_HTTPHEADER, headers);
-
-    curl_easy_setopt(_curl, CURLOPT_ERRORBUFFER, errbuf);
-    res = curl_easy_perform(_curl);
-
-    long httpCode = 0;
-    curl_easy_getinfo(_curl, CURLINFO_RESPONSE_CODE, &httpCode);
-
-    curl_slist_free_all(headers);
-
-    if (httpCode != 200) {
-      std::stringstream ss;
-      ss << "QLever backend returned status code " << httpCode;
-      ss << "\n";
-      ss << _raw;
-      throw std::runtime_error(ss.str());
-    }
-
-    if (exceptionPtr) std::rethrow_exception(exceptionPtr);
-  } else {
-    LOG(ERROR) << "[REQUESTREADER] Failed to perform curl request.";
-    return;
-  }
-
-  if (res != CURLE_OK) {
-    std::stringstream ss;
-    ss << "QLever backend request failed: ";
-    size_t len = strlen(errbuf);
-    if (len > 0) {
-      LOG(ERROR) << "[REQUESTREADER] " << errbuf;
-      ss << errbuf;
-    } else {
-      LOG(ERROR) << "[REQUESTREADER] " << curl_easy_strerror(res);
-      ss << curl_easy_strerror(res);
-    }
-
-    throw std::runtime_error(ss.str());
-  }
+  performCurlRequest(_curl, _backendUrl, queryFields(query),
+                     "text/tab-separated-values", writeCb, ptr, &_raw,
+                     &exceptionPtr);
 }
 
 // _____________________________________________________________________________
@@ -525,44 +434,16 @@ size_t RequestReader::writeCbString(void* contents, size_t size, size_t nmemb,
 // _____________________________________________________________________________
 std::string RequestReader::requestIndexHash(const std::string& configHash) {
   // TODO: move this function into Reader class
-  CURLcode res;
-  char errbuf[CURL_ERROR_SIZE];
   std::string response;
+  std::string url = _backendUrl + "/?cmd=get-index-id";
 
-  if (_curl) {
-    std::string url = _backendUrl + "/?cmd=get-index-id";
-    petrimapsCurlSetup(_curl);
-    curl_easy_setopt(_curl, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(_curl, CURLOPT_WRITEFUNCTION,
-                     RequestReader::writeCbString);
-    curl_easy_setopt(_curl, CURLOPT_WRITEDATA, &response);
-    curl_easy_setopt(_curl, CURLOPT_ERRORBUFFER, errbuf);
-
-    res = curl_easy_perform(_curl);
-
-    if (res != CURLE_OK) {
-      size_t len = strlen(errbuf);
-      if (len > 0) {
-        LOG(ERROR) << "[GEOMCACHE] " << errbuf;
-      } else {
-        LOG(ERROR) << "[GEOMCACHE] " << curl_easy_strerror(res);
-      }
-
-      return "";
-    }
-
-    long httpCode = 0;
-    curl_easy_getinfo(_curl, CURLINFO_RESPONSE_CODE, &httpCode);
-
-    if (httpCode != 200) {
-      LOG(WARN) << "QLever backend returned status code " << httpCode
-                << " for index hash.";
-      return "";
-    }
-
-    return INDEX_HASH_PREFIX + "|" + configHash + "|" + response;
-  } else {
-    LOG(ERROR) << "[GEOMCACHE] Failed to perform curl request for index hash.";
+  try {
+    performCurlRequest(_curl, url, "", "", RequestReader::writeCbString,
+                       &response, nullptr, nullptr);
+  } catch (const std::exception& e) {
+    LOG(WARN) << "[GEOMCACHE] Could not obtain index hash: " << e.what();
     return "";
   }
+
+  return INDEX_HASH_PREFIX + "|" + configHash + "|" + response;
 }

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -81,7 +81,7 @@ void petrimaps::performCurlRequest(
   }
   if (xForwardHeader.size()) {
     headers = curl_slist_append(headers,
-                                ("X-Forwarded-For: " + xForwardHeader).c_str());
+                                ("X-Real-IP: " + xForwardHeader).c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
 
@@ -399,7 +399,7 @@ std::string petrimaps::canonizeURL(const std::string& inURL,
   struct curl_slist* headers = 0;
   if (remoteAddr.size()) {
     headers =
-        curl_slist_append(headers, ("X-Forwarded-For: " + remoteAddr).c_str());
+        curl_slist_append(headers, ("X-Real-IP: " + remoteAddr).c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
 

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -2,7 +2,10 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Patrick Brosi <brosi@informatik.uni-freiburg.de>
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
 #include <stdint.h>
+#include <sys/socket.h>
 
 #include <cstring>
 #include <string>
@@ -23,7 +26,7 @@ const static std::string INDEX_HASH_PREFIX = "_5_";
 // _____________________________________________________________________________
 void petrimaps::performCurlRequest(
     const std::string& url, const std::string& postFields,
-    const std::string& acceptHeader,
+    const std::string& acceptHeader, const std::string& xForwardHeader,
     const std::function<void(const char*, size_t)>& parse,
     const std::string* raw) {
   CURL* curl = curl_easy_init();
@@ -74,6 +77,11 @@ void petrimaps::performCurlRequest(
   struct curl_slist* headers = 0;
   if (acceptHeader.size()) {
     headers = curl_slist_append(headers, ("Accept: " + acceptHeader).c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+  }
+  if (xForwardHeader.size()) {
+    headers = curl_slist_append(headers,
+                                ("X-Forwarded-For: " + xForwardHeader).c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
 
@@ -127,44 +135,48 @@ std::vector<std::string> RequestReader::requestColumns(
 }
 
 // _____________________________________________________________________________
-void RequestReader::requestIds(const std::string& query) {
+void RequestReader::requestIds(const std::string& query,
+                               const std::string& remoteAddr) {
   _raw.clear();
   _raw.reserve(10000);
 
   performCurlRequest(
-      _backendUrl, queryFields(query), "application/octet-stream",
+      _backendUrl, queryFields(query), "application/octet-stream", remoteAddr,
       [this](const char* c, size_t n) { parseIds(c, n); }, &_raw);
 }
 
 // _____________________________________________________________________________
 std::map<size_t, std::pair<double, double>> RequestReader::requestRasterMeta(
-    const std::string& query) {
+    const std::string& query, const std::string& remoteAddr) {
   _curRasterFieldDimensions = {};
 
   _raw.clear();
   _raw.reserve(10000);
 
   performCurlRequest(
-      _backendUrl, queryFields(query), "application/octet-stream",
+      _backendUrl, queryFields(query), "application/octet-stream", remoteAddr,
       [this](const char* c, size_t n) { parseRasterMeta(c, n); }, &_raw);
 
   return _curRasterFieldDimensions;
 }
 
 // _____________________________________________________________________________
-void RequestReader::requestRows(const std::string& query) {
-  return requestRows(query, [this](const char* c, size_t n) { parse(c, n); });
+void RequestReader::requestRows(const std::string& query,
+                                const std::string& remoteAddr) {
+  return requestRows(
+      query, [this](const char* c, size_t n) { parse(c, n); }, remoteAddr);
 }
 
 // _____________________________________________________________________________
 void RequestReader::requestRows(
     const std::string& query,
-    const std::function<void(const char*, size_t)>& parse) {
+    const std::function<void(const char*, size_t)>& parse,
+    const std::string& remoteAddr) {
   _raw.clear();
   _raw.reserve(10000);
 
   performCurlRequest(_backendUrl, queryFields(query),
-                     "text/tab-separated-values", parse, &_raw);
+                     "text/tab-separated-values", remoteAddr, parse, &_raw);
 }
 
 // _____________________________________________________________________________
@@ -370,7 +382,8 @@ std::string petrimaps::normalizeURL(const std::string& inURL) {
 }
 
 // _____________________________________________________________________________
-std::string petrimaps::canonizeURL(const std::string& inURL) {
+std::string petrimaps::canonizeURL(const std::string& inURL,
+                                   const std::string& remoteAddr) {
   CURL* curl = curl_easy_init();
   if (!curl) {
     std::stringstream ss;
@@ -383,8 +396,16 @@ std::string petrimaps::canonizeURL(const std::string& inURL) {
   curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 10L);
   curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
 
+  struct curl_slist* headers = 0;
+  if (remoteAddr.size()) {
+    headers =
+        curl_slist_append(headers, ("X-Forwarded-For: " + remoteAddr).c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+  }
+
   CURLcode res = curl_easy_perform(curl);
   if (res != CURLE_OK) {
+    if (headers) curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
     std::stringstream ss;
     ss << "Could not canonize URL " << inURL;
@@ -397,6 +418,7 @@ std::string petrimaps::canonizeURL(const std::string& inURL) {
   curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &effective);
 
   if (!effective) {
+    if (headers) curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
     std::stringstream ss;
     ss << "Could not canonize URL " << inURL;
@@ -405,19 +427,47 @@ std::string petrimaps::canonizeURL(const std::string& inURL) {
 
   std::string ret(effective);
 
+  if (headers) curl_slist_free_all(headers);
   curl_easy_cleanup(curl);
   return normalizeURL(ret);
 }
 
 // _____________________________________________________________________________
+std::string petrimaps::remoteAddress(int sock) {
+  struct sockaddr_storage addr;
+  socklen_t len = sizeof(addr);
+  if (getpeername(sock, reinterpret_cast<struct sockaddr*>(&addr), &len) != 0) {
+    return "";
+  }
+
+  char buf[INET6_ADDRSTRLEN] = {0};
+
+  if (addr.ss_family == AF_INET) {
+    auto* s = reinterpret_cast<struct sockaddr_in*>(&addr);
+    inet_ntop(AF_INET, &s->sin_addr, buf, sizeof(buf));
+  } else if (addr.ss_family == AF_INET6) {
+    auto* s = reinterpret_cast<struct sockaddr_in6*>(&addr);
+    inet_ntop(AF_INET6, &s->sin6_addr, buf, sizeof(buf));
+
+    // unwrap IPv4-mapped IPv6 addresses
+    std::string ip(buf);
+    if (ip.rfind("::ffff:", 0) == 0 && ip.find('.') != std::string::npos)
+      return ip.substr(7);
+
+    return ip;
+  }
+
+  return buf;
+}
+
+// _____________________________________________________________________________
 std::string RequestReader::requestIndexHash(const std::string& configHash) {
-  // TODO: move this function into Reader class
   std::string response;
   std::string url = _backendUrl + "/?cmd=get-index-id";
 
   try {
     performCurlRequest(
-        url, "", "",
+        url, "", "", "",
         [&response](const char* c, size_t n) { response.append(c, n); },
         nullptr);
   } catch (const std::exception& e) {

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -79,7 +79,6 @@ void petrimaps::performCurlRequest(
     headers = curl_slist_append(headers, ("Accept: " + acceptHeader).c_str());
   }
   if (xRealIP.size()) {
-    LOG(INFO) << "[SERVER] Remote address is " << xRealIP;
     headers = curl_slist_append(headers,
                                 ("X-Real-IP: " + xRealIP).c_str());
   }
@@ -399,7 +398,6 @@ std::string petrimaps::canonizeURL(const std::string& inURL,
 
   struct curl_slist* headers = 0;
   if (remoteAddr.size()) {
-    LOG(INFO) << "[SERVER] Remote address is " << remoteAddr;
     headers =
         curl_slist_append(headers, ("X-Real-IP: " + remoteAddr).c_str());
   }

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -77,13 +77,14 @@ void petrimaps::performCurlRequest(
   struct curl_slist* headers = 0;
   if (acceptHeader.size()) {
     headers = curl_slist_append(headers, ("Accept: " + acceptHeader).c_str());
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
   if (xForwardHeader.size()) {
+    LOG(INFO) << "[SERVER] Remote address is " << remoteAddr;
     headers = curl_slist_append(headers,
                                 ("X-Real-IP: " + xForwardHeader).c_str());
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
+
+  if (headers) curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 
   CURLcode res = curl_easy_perform(curl);
 
@@ -398,10 +399,12 @@ std::string petrimaps::canonizeURL(const std::string& inURL,
 
   struct curl_slist* headers = 0;
   if (remoteAddr.size()) {
+    LOG(INFO) << "[SERVER] Remote address is " << remoteAddr;
     headers =
         curl_slist_append(headers, ("X-Real-IP: " + remoteAddr).c_str());
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
+
+  if (headers) curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 
   CURLcode res = curl_easy_perform(curl);
   if (res != CURLE_OK) {

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -22,10 +22,12 @@ const static std::string INDEX_HASH_PREFIX = "_5_";
 
 // _____________________________________________________________________________
 void petrimaps::performCurlRequest(
-    CURL* curl, const std::string& url, const std::string& postFields,
+    const std::string& url, const std::string& postFields,
     const std::string& acceptHeader,
-    size_t (*writeCb)(void*, size_t, size_t, void*), void* writeData,
-    const std::string* raw, std::exception_ptr* exceptionPtr) {
+    const std::function<void(const char*, size_t)>& parse,
+    const std::string* raw) {
+  CURL* curl = curl_easy_init();
+
   if (!curl) {
     throw std::runtime_error("Failed to perform curl request.");
   }
@@ -33,14 +35,40 @@ void petrimaps::performCurlRequest(
   char errbuf[CURL_ERROR_SIZE];
   errbuf[0] = 0;
 
+  // this is a context that holds to things: a std::function for parsing, and
+  // an exception_ptr for storing any exception encountered during parsing (for
+  // later rethrow)
+  struct CallbackContext {
+    const std::function<void(const char*, size_t)>& parse;
+    std::exception_ptr exception;
+  } cbContext{parse, nullptr};
+
   petrimapsCurlSetup(curl);
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+
+  // if we have POST fields, add them
   if (postFields.size()) {
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postFields.c_str());
   }
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCb);
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, writeData);
+
+  size_t (*cb)(void* contents, size_t size, size_t nmemb, void* userp) =
+      [](void* contents, size_t size, size_t nmemb, void* userp) -> size_t {
+    size_t realsize = size * nmemb;
+    auto* c = static_cast<CallbackContext*>(userp);
+    try {
+      c->parse(static_cast<const char*>(contents), realsize);
+    } catch (...) {
+      // store exception, then return with an error (aborts curl request)
+      c->exception = std::current_exception();
+      return CURLE_WRITE_ERROR;
+    }
+    return realsize;
+  };
+
+  // any newly read block will be given to the parse() method of the handed cb
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, cb);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &cbContext);
   curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
 
   struct curl_slist* headers = 0;
@@ -55,6 +83,7 @@ void petrimaps::performCurlRequest(
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
 
   if (headers) curl_slist_free_all(headers);
+  curl_easy_cleanup(curl);
 
   if (httpCode != 200) {
     std::stringstream ss;
@@ -63,9 +92,8 @@ void petrimaps::performCurlRequest(
     throw std::runtime_error(ss.str());
   }
 
-  // an exception thrown inside the write callback takes precedence over a
-  // generic transport error
-  if (exceptionPtr && *exceptionPtr) std::rethrow_exception(*exceptionPtr);
+  // rethrow any exception encountered during write callback
+  if (cbContext.exception) std::rethrow_exception(cbContext.exception);
 
   if (res != CURLE_OK) {
     std::stringstream ss;
@@ -103,9 +131,9 @@ void RequestReader::requestIds(const std::string& query) {
   _raw.clear();
   _raw.reserve(10000);
 
-  performCurlRequest(_curl, _backendUrl, queryFields(query),
-                     "application/octet-stream", RequestReader::writeCbIds,
-                     this, &_raw, &exceptionPtr);
+  performCurlRequest(
+      _backendUrl, queryFields(query), "application/octet-stream",
+      [this](const char* c, size_t n) { parseIds(c, n); }, &_raw);
 }
 
 // _____________________________________________________________________________
@@ -117,34 +145,36 @@ std::map<size_t, std::pair<double, double>> RequestReader::requestRasterMeta(
   _raw.reserve(10000);
 
   performCurlRequest(
-      _curl, _backendUrl, queryFields(query), "application/octet-stream",
-      RequestReader::writeCbRasterMeta, this, &_raw, &exceptionPtr);
+      _backendUrl, queryFields(query), "application/octet-stream",
+      [this](const char* c, size_t n) { parseRasterMeta(c, n); }, &_raw);
 
   return _curRasterFieldDimensions;
 }
 
 // _____________________________________________________________________________
 void RequestReader::requestRows(const std::string& query) {
-  return requestRows(query, RequestReader::writeCb, this);
+  return requestRows(query, [this](const char* c, size_t n) { parse(c, n); });
 }
 
 // _____________________________________________________________________________
-void RequestReader::requestRows(const std::string& query,
-                                size_t (*writeCb)(void*, size_t, size_t, void*),
-                                void* ptr) {
+void RequestReader::requestRows(
+    const std::string& query,
+    const std::function<void(const char*, size_t)>& parse) {
   _raw.clear();
   _raw.reserve(10000);
 
-  performCurlRequest(_curl, _backendUrl, queryFields(query),
-                     "text/tab-separated-values", writeCb, ptr, &_raw,
-                     &exceptionPtr);
+  performCurlRequest(_backendUrl, queryFields(query),
+                     "text/tab-separated-values", parse, &_raw);
 }
 
 // _____________________________________________________________________________
 std::string RequestReader::queryFields(const std::string& query) const {
-  auto escStr = curl_easy_escape(_curl, query.c_str(), query.size());
+  // TODO: dont spin up an entire CURL instance here, is this necessary?
+  CURL* curl = curl_easy_init();
+  auto escStr = curl_easy_escape(curl, query.c_str(), query.size());
   std::string esc = escStr;
   curl_free(escStr);
+  curl_easy_cleanup(curl);
 
   return "send=18446744073709551615&query=" + esc;
 }
@@ -154,51 +184,6 @@ size_t petrimaps::writeStringCb(void* contents, size_t size, size_t nmemb,
                                 void* userp) {
   ((std::string*)userp)->append((char*)contents, size * nmemb);
   return size * nmemb;
-}
-
-// _____________________________________________________________________________
-size_t RequestReader::writeCb(void* contents, size_t size, size_t nmemb,
-                              void* userp) {
-  size_t realsize = size * nmemb;
-  try {
-    static_cast<RequestReader*>(userp)->parse(
-        static_cast<const char*>(contents), realsize);
-  } catch (...) {
-    static_cast<RequestReader*>(userp)->exceptionPtr = std::current_exception();
-    return CURLE_WRITE_ERROR;
-  }
-
-  return realsize;
-}
-
-// _____________________________________________________________________________
-size_t RequestReader::writeCbIds(void* contents, size_t size, size_t nmemb,
-                                 void* userp) {
-  size_t realsize = size * nmemb;
-  try {
-    static_cast<RequestReader*>(userp)->parseIds(
-        static_cast<const char*>(contents), realsize);
-  } catch (...) {
-    static_cast<RequestReader*>(userp)->exceptionPtr = std::current_exception();
-    return CURLE_WRITE_ERROR;
-  }
-
-  return realsize;
-}
-
-// _____________________________________________________________________________
-size_t RequestReader::writeCbRasterMeta(void* contents, size_t size,
-                                        size_t nmemb, void* userp) {
-  size_t realsize = size * nmemb;
-  try {
-    static_cast<RequestReader*>(userp)->parseRasterMeta(
-        static_cast<const char*>(contents), realsize);
-  } catch (...) {
-    static_cast<RequestReader*>(userp)->exceptionPtr = std::current_exception();
-    return CURLE_WRITE_ERROR;
-  }
-
-  return realsize;
 }
 
 // _____________________________________________________________________________
@@ -425,21 +410,16 @@ std::string petrimaps::canonizeURL(const std::string& inURL) {
 }
 
 // _____________________________________________________________________________
-size_t RequestReader::writeCbString(void* contents, size_t size, size_t nmemb,
-                                    void* userp) {
-  ((std::string*)userp)->append((char*)contents, size * nmemb);
-  return size * nmemb;
-}
-
-// _____________________________________________________________________________
 std::string RequestReader::requestIndexHash(const std::string& configHash) {
   // TODO: move this function into Reader class
   std::string response;
   std::string url = _backendUrl + "/?cmd=get-index-id";
 
   try {
-    performCurlRequest(_curl, url, "", "", RequestReader::writeCbString,
-                       &response, nullptr, nullptr);
+    performCurlRequest(
+        url, "", "",
+        [&response](const char* c, size_t n) { response.append(c, n); },
+        nullptr);
   } catch (const std::exception& e) {
     LOG(WARN) << "[GEOMCACHE] Could not obtain index hash: " << e.what();
     return "";

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "util/Misc.h"
+#include "util/log/Log.h"
 
 #ifndef PETRIMAPS_MISC_H_
 #define PETRIMAPS_MISC_H_
@@ -129,7 +130,7 @@ inline std::string httpRequest(const std::string& url,
   }
   struct curl_slist* headers = 0;
   if (xForwardHeader.size()) {
-    LOG(INFO) << "[SERVER] Remote address is " << xForwardHeader;
+    LOG(util::INFO) << "[SERVER] Remote address is " << xForwardHeader;
     headers = curl_slist_append(headers,
                                 ("X-Real-IP: " + xForwardHeader).c_str());
   }

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -72,7 +72,7 @@ std::string remoteAddress(int sock);
 
 void performCurlRequest(const std::string& url, const std::string& postFields,
                         const std::string& acceptHeader,
-                        const std::string& xForwardHeader,
+                        const std::string& xRealIP,
                         const std::function<void(const char*, size_t)>& parse,
                         const std::string* raw);
 
@@ -115,7 +115,7 @@ size_t writeStringCb(void* contents, size_t size, size_t nmemb, void* userp);
 
 inline std::string httpRequest(const std::string& url,
                                const std::string& postFields = "",
-                               const std::string& xForwardHeader = "") {
+                               const std::string& xRealIP = "") {
   CURL* curl = curl_easy_init();
   CURLcode res;
   char errbuf[CURL_ERROR_SIZE];
@@ -129,10 +129,10 @@ inline std::string httpRequest(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postFields.c_str());
   }
   struct curl_slist* headers = 0;
-  if (xForwardHeader.size()) {
-    LOG(util::INFO) << "[SERVER] Remote address is " << xForwardHeader;
+  if (xRealIP.size()) {
+    LOG(util::INFO) << "[SERVER] Remote address is " << xRealIP;
     headers = curl_slist_append(headers,
-                                ("X-Real-IP: " + xForwardHeader).c_str());
+                                ("X-Real-IP: " + xRealIP).c_str());
   }
   if (headers) curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeStringCb);

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -129,7 +129,7 @@ inline std::string httpRequest(const std::string& url,
   }
   struct curl_slist* headers = 0;
   if (xForwardHeader.size()) {
-    LOG(INFO) << "[SERVER] Remote address is " << remoteAddr;
+    LOG(INFO) << "[SERVER] Remote address is " << xForwardHeader;
     headers = curl_slist_append(headers,
                                 ("X-Real-IP: " + xForwardHeader).c_str());
   }

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 #include <exception>
+#include <functional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -66,12 +67,11 @@ inline int16_t isMCoord(int16_t c) {
 std::string normalizeURL(const std::string& inURL);
 std::string canonizeURL(const std::string& inURL);
 
-void performCurlRequest(CURL* curl, const std::string& url,
+void performCurlRequest(const std::string& url,
                         const std::string& postFields,
                         const std::string& acceptHeader,
-                        size_t (*writeCb)(void*, size_t, size_t, void*),
-                        void* writeData, const std::string* raw,
-                        std::exception_ptr* exceptionPtr);
+                        const std::function<void(const char*, size_t)>& parse,
+                        const std::string* raw);
 
 class OutOfMemoryError : public std::exception {
  public:
@@ -164,7 +164,6 @@ struct RequestReader {
                          size_t geomFields, size_t valFields,
                          size_t rasterMetaFields)
       : _backendUrl(backendUrl),
-        _curl(curl_easy_init()),
         _maxMemory(maxMemory),
         _geomFields(geomFields),
         _valFields(valFields),
@@ -172,9 +171,6 @@ struct RequestReader {
     _ids.resize(geomFields);
     _vals.resize(valFields);
     _rasterMetas.resize(rasterMetaFields);
-  }
-  ~RequestReader() {
-    if (_curl) curl_easy_cleanup(_curl);
   }
 
   std::vector<std::string> requestColumns(const std::string& query);
@@ -184,23 +180,14 @@ struct RequestReader {
   std::string requestIndexHash(const std::string& configHash);
   void requestRows(const std::string& qurl);
   void requestRows(const std::string& query,
-                   size_t (*writeCb)(void*, size_t, size_t, void*), void* ptr);
+                   const std::function<void(const char*, size_t)>& parse);
   void parse(const char*, size_t size);
   void parseIds(const char*, size_t size);
   void parseRasterMeta(const char*, size_t size);
 
-  static size_t writeCb(void* contents, size_t size, size_t nmemb, void* userp);
-  static size_t writeCbIds(void* contents, size_t size, size_t nmemb,
-                           void* userp);
-  static size_t writeCbRasterMeta(void* contents, size_t size, size_t nmemb,
-                                  void* userp);
-  static size_t writeCbString(void* contents, size_t size, size_t nmemb,
-                              void* userp);
-
   std::string queryFields(const std::string& query) const;
 
   std::string _backendUrl;
-  CURL* _curl;
 
   std::vector<std::string> _colNames;
   size_t _curCol = 0;
@@ -229,8 +216,6 @@ struct RequestReader {
   size_t _geomFields;
   size_t _valFields;
   size_t _rasterMetaFields;
-
-  std::exception_ptr exceptionPtr;
 };
 
 }  // namespace petrimaps

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -130,7 +130,7 @@ inline std::string httpRequest(const std::string& url,
   struct curl_slist* headers = 0;
   if (xForwardHeader.size()) {
     headers = curl_slist_append(headers,
-                                ("X-Forwarded-For: " + xForwardHeader).c_str());
+                                ("X-Real-IP: " + xForwardHeader).c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeStringCb);

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -65,11 +65,13 @@ inline int16_t isMCoord(int16_t c) {
 }
 
 std::string normalizeURL(const std::string& inURL);
-std::string canonizeURL(const std::string& inURL);
+std::string canonizeURL(const std::string& inURL,
+                        const std::string& remoteAddr);
+std::string remoteAddress(int sock);
 
-void performCurlRequest(const std::string& url,
-                        const std::string& postFields,
+void performCurlRequest(const std::string& url, const std::string& postFields,
                         const std::string& acceptHeader,
+                        const std::string& xForwardHeader,
                         const std::function<void(const char*, size_t)>& parse,
                         const std::string* raw);
 
@@ -111,7 +113,8 @@ inline void petrimapsCurlSetup(CURL* curl) {
 size_t writeStringCb(void* contents, size_t size, size_t nmemb, void* userp);
 
 inline std::string httpRequest(const std::string& url,
-                               const std::string& postFields = "") {
+                               const std::string& postFields = "",
+                               const std::string& xForwardHeader = "") {
   CURL* curl = curl_easy_init();
   CURLcode res;
   char errbuf[CURL_ERROR_SIZE];
@@ -123,6 +126,12 @@ inline std::string httpRequest(const std::string& url,
   if (postFields.size()) {
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postFields.c_str());
+  }
+  struct curl_slist* headers = 0;
+  if (xForwardHeader.size()) {
+    headers = curl_slist_append(headers,
+                                ("X-Forwarded-For: " + xForwardHeader).c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeStringCb);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resString);
@@ -137,6 +146,9 @@ inline std::string httpRequest(const std::string& url,
     ss << "Remote server returned status code " << httpCode;
     ss << "\n";
     ss << resString;
+
+    if (headers) curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
     throw std::runtime_error(ss.str());
   }
 
@@ -150,10 +162,12 @@ inline std::string httpRequest(const std::string& url,
       ss << curl_easy_strerror(res);
     }
 
+    if (headers) curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
     throw std::runtime_error(ss.str());
   }
 
+  if (headers) curl_slist_free_all(headers);
   curl_easy_cleanup(curl);
 
   return resString;
@@ -174,13 +188,14 @@ struct RequestReader {
   }
 
   std::vector<std::string> requestColumns(const std::string& query);
-  void requestIds(const std::string& qurl);
+  void requestIds(const std::string& qurl, const std::string& remoteAddr);
   std::map<size_t, std::pair<double, double>> requestRasterMeta(
-      const std::string& query);
+      const std::string& query, const std::string& remoteAddr);
   std::string requestIndexHash(const std::string& configHash);
-  void requestRows(const std::string& qurl);
+  void requestRows(const std::string& qurl, const std::string& remoteAddr);
   void requestRows(const std::string& query,
-                   const std::function<void(const char*, size_t)>& parse);
+                   const std::function<void(const char*, size_t)>& parse,
+                   const std::string& remoteAddr);
   void parse(const char*, size_t size);
   void parseIds(const char*, size_t size);
   void parseRasterMeta(const char*, size_t size);

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -129,10 +129,11 @@ inline std::string httpRequest(const std::string& url,
   }
   struct curl_slist* headers = 0;
   if (xForwardHeader.size()) {
+    LOG(INFO) << "[SERVER] Remote address is " << remoteAddr;
     headers = curl_slist_append(headers,
                                 ("X-Real-IP: " + xForwardHeader).c_str());
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
+  if (headers) curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeStringCb);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resString);
   curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -5,6 +5,7 @@
 #include <curl/curl.h>
 #include <stdint.h>
 
+#include <exception>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -64,6 +65,13 @@ inline int16_t isMCoord(int16_t c) {
 
 std::string normalizeURL(const std::string& inURL);
 std::string canonizeURL(const std::string& inURL);
+
+void performCurlRequest(CURL* curl, const std::string& url,
+                        const std::string& postFields,
+                        const std::string& acceptHeader,
+                        size_t (*writeCb)(void*, size_t, size_t, void*),
+                        void* writeData, const std::string* raw,
+                        std::exception_ptr* exceptionPtr);
 
 class OutOfMemoryError : public std::exception {
  public:
@@ -142,15 +150,19 @@ inline std::string httpRequest(const std::string& url,
       ss << curl_easy_strerror(res);
     }
 
+    curl_easy_cleanup(curl);
     throw std::runtime_error(ss.str());
   }
+
+  curl_easy_cleanup(curl);
 
   return resString;
 }
 
 struct RequestReader {
   explicit RequestReader(const std::string& backendUrl, size_t maxMemory,
-                         size_t geomFields, size_t valFields, size_t rasterMetaFields)
+                         size_t geomFields, size_t valFields,
+                         size_t rasterMetaFields)
       : _backendUrl(backendUrl),
         _curl(curl_easy_init()),
         _maxMemory(maxMemory),

--- a/src/qlever-petrimaps/PetriMapsMain.cpp
+++ b/src/qlever-petrimaps/PetriMapsMain.cpp
@@ -49,7 +49,7 @@ petrimaps::GeomCacheConfig cacheConfigFromDisk(const std::string& fname) {
   std::string canonized;
 
   try {
-    canonized = petrimaps::canonizeURL(url);
+    canonized = petrimaps::canonizeURL(url, "");
   } catch (std::runtime_error& e) {
     LOG(WARN) << fname << "' seems to be a legacy cache file, delete it!";
     throw;

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -29,7 +29,7 @@ using util::LogLevel::INFO;
 using util::LogLevel::WARN;
 
 // _____________________________________________________________________________
-void Requestor::request() {
+void Requestor::request(const std::string& remoteAddr) {
   std::lock_guard<std::mutex> guard(_m);
 
   if (_ready) return;
@@ -65,7 +65,7 @@ void Requestor::request() {
     LOG(INFO) << "[REQUESTOR] Requesting IDs/weights for query " << _rcfg.query;
     LOG(INFO) << "[REQUESTOR] Prepped query: " << prepedGeomQuery;
 
-    reader.requestIds(prepedGeomQuery);
+    reader.requestIds(prepedGeomQuery, remoteAddr);
 
     size_t totNumIds = 0;
     for (size_t i = 0; i < _geomColumns.size(); i++)
@@ -442,7 +442,7 @@ void Requestor::request() {
 
 // _____________________________________________________________________________
 std::vector<std::pair<std::string, std::string>> Requestor::requestRow(
-    uint64_t row) const {
+    uint64_t row, const std::string& remoteAddr) const {
   if (!_cache->ready()) {
     throw std::runtime_error("Geom cache not ready");
   }
@@ -453,7 +453,7 @@ std::vector<std::pair<std::string, std::string>> Requestor::requestRow(
 
   LOG(INFO) << "[REQUESTOR] Row query is " << query;
 
-  reader.requestRows(query);
+  reader.requestRows(query, remoteAddr);
 
   if (reader.rows.size() == 0) return {};
 
@@ -464,19 +464,23 @@ std::vector<std::pair<std::string, std::string>> Requestor::requestRow(
 void Requestor::requestRows(
     std::function<
         void(std::vector<std::vector<std::pair<std::string, std::string>>>)>
-        cb) const {
+        cb,
+    const std::string& remoteAddr) const {
   if (!_cache->ready()) {
     throw std::runtime_error("Geom cache not ready");
   }
   RequestReader reader(_cache->getConfig().backend, _maxMemory, 0, 0, 0);
   LOG(INFO) << "[REQUESTOR] Requesting rows for query " << _rcfg.query;
 
-  reader.requestRows(_rcfg.query, [&reader, &cb](const char* c, size_t n) {
-    // parse this block of rows and give them to the callback
-    reader.rows = {};
-    reader.parse(c, n);
-    cb(reader.rows);
-  });
+  reader.requestRows(
+      _rcfg.query,
+      [&reader, &cb](const char* c, size_t n) {
+        // parse this block of rows and give them to the callback
+        reader.rows = {};
+        reader.parse(c, n);
+        cb(reader.rows);
+      },
+      remoteAddr);
 }
 
 // _____________________________________________________________________________
@@ -532,9 +536,10 @@ std::string Requestor::prepQueryRow(std::string query, uint64_t row) const {
 
 // _____________________________________________________________________________
 const ResObj Requestor::getNearest(util::geo::DPoint rp, double rad, double res,
-                                   util::geo::FBox fullbox) const {
+                                   util::geo::FBox fullbox,
+                                   const std::string& remoteAddr) const {
   for (size_t lid = 0; lid < getNumFields(); lid++) {
-    auto r = getNearest(lid, rp, rad, res, fullbox);
+    auto r = getNearest(lid, rp, rad, res, fullbox, remoteAddr);
     if (r.has) return r;
   }
 
@@ -544,7 +549,8 @@ const ResObj Requestor::getNearest(util::geo::DPoint rp, double rad, double res,
 // _____________________________________________________________________________
 const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
                                    double rad, double res,
-                                   util::geo::FBox fullbox) const {
+                                   util::geo::FBox fullbox,
+                                   const std::string& remoteAddr) const {
   if (!_cache->ready()) {
     throw std::runtime_error("Geom cache not ready");
   }
@@ -712,7 +718,7 @@ const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
             nearest,
             fieldId,
             points.size() == 1 ? points[0] : util::geo::centroid(points),
-            requestRow(row),
+            requestRow(row, remoteAddr),
             points,
             geomLineGeoms(fieldId, nearest, rad / 10),
             geomPolyGeoms(fieldId, nearest, rad / 10)};
@@ -728,7 +734,7 @@ const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
               nearestL,
               fieldId,
               {frp.getX(), frp.getY()},
-              requestRow(_objects[fieldId][nearestL].second),
+              requestRow(_objects[fieldId][nearestL].second, remoteAddr),
               geomPointGeoms(fieldId, nearestL, res),
               geomLineGeoms(fieldId, nearestL, rad / 10),
               geomPolyGeoms(fieldId, nearestL, rad / 10)};
@@ -739,7 +745,7 @@ const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
               nearestL,
               fieldId,
               fp,
-              requestRow(_objects[fieldId][nearestL].second),
+              requestRow(_objects[fieldId][nearestL].second, remoteAddr),
               geomPointGeoms(fieldId, nearestL, res),
               geomLineGeoms(fieldId, nearestL, rad / 10),
               geomPolyGeoms(fieldId, nearestL, rad / 10)};

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -471,26 +471,12 @@ void Requestor::requestRows(
   RequestReader reader(_cache->getConfig().backend, _maxMemory, 0, 0, 0);
   LOG(INFO) << "[REQUESTOR] Requesting rows for query " << _rcfg.query;
 
-  ReaderCbPair cbPair{&reader, cb};
-
-  reader.requestRows(
-      _rcfg.query,
-      [](void* contents, size_t size, size_t nmemb, void* ptr) {
-        size_t realsize = size * nmemb;
-        auto pr = static_cast<ReaderCbPair*>(ptr);
-        try {
-          // clear rows
-          pr->reader->rows = {};
-          pr->reader->parse(static_cast<const char*>(contents), realsize);
-          pr->cb(pr->reader->rows);
-        } catch (...) {
-          pr->reader->exceptionPtr = std::current_exception();
-          return static_cast<size_t>(CURLE_WRITE_ERROR);
-        }
-
-        return realsize;
-      },
-      &cbPair);
+  reader.requestRows(_rcfg.query, [&reader, &cb](const char* c, size_t n) {
+    // parse this block of rows and give them to the callback
+    reader.rows = {};
+    reader.parse(c, n);
+    cb(reader.rows);
+  });
 }
 
 // _____________________________________________________________________________

--- a/src/qlever-petrimaps/server/Requestor.h
+++ b/src/qlever-petrimaps/server/Requestor.h
@@ -69,13 +69,6 @@ struct ResObj {
   util::geo::MultiPolygon<double> poly;
 };
 
-struct ReaderCbPair {
-  RequestReader* reader;
-  std::function<void(
-      std::vector<std::vector<std::pair<std::string, std::string>>>)>
-      cb;
-};
-
 class Requestor {
  public:
   Requestor() : _maxMemory(-1) {}

--- a/src/qlever-petrimaps/server/Requestor.h
+++ b/src/qlever-petrimaps/server/Requestor.h
@@ -107,15 +107,16 @@ class Requestor {
     }
   }
 
-  void request();
+  void request(const std::string& remoteAddr);
 
   std::vector<std::pair<std::string, std::string>> requestRow(
-      uint64_t row) const;
+      uint64_t row, const std::string& remoteAddr) const;
 
   void requestRows(
       std::function<
           void(std::vector<std::vector<std::pair<std::string, std::string>>>)>
-          cb) const;
+          cb,
+      const std::string& remoteAddr) const;
 
   const petrimaps::Grid<ID_TYPE, float, float>& getPointGrid(
       size_t fieldId) const {
@@ -191,10 +192,12 @@ class Requestor {
   }
 
   const ResObj getNearest(size_t lid, util::geo::DPoint p, double rad,
-                          double res, util::geo::FBox box) const;
+                          double res, util::geo::FBox box,
+                          const std::string& remoteAddr) const;
 
   const ResObj getNearest(util::geo::DPoint p, double rad, double res,
-                          util::geo::FBox box) const;
+                          util::geo::FBox box,
+                          const std::string& remoteAddr) const;
 
   const ResObj getGeom(size_t lid, size_t id, double rad) const;
 

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -806,7 +806,8 @@ util::http::Answer Server::handleTouchReq(const Params& pars,
     configJson = pars.find("cfg")->second;
   }
 
-  auto backendCfg = getGeomCacheConfig(backend, accessToken, configJson, remoteAddr);
+  auto backendCfg =
+      getGeomCacheConfig(backend, accessToken, configJson, remoteAddr);
 
   createCache(backendCfg);
   std::shared_ptr<GeomCache> cache = _caches[backend];
@@ -1338,7 +1339,8 @@ util::http::Answer Server::handleExportReq(const Params& pars, int sock) const {
 }
 
 // _____________________________________________________________________________
-util::http::Answer Server::handleLoadStatusReq(const Params& pars, int sock) const {
+util::http::Answer Server::handleLoadStatusReq(const Params& pars,
+                                               int sock) const {
   if (pars.count("backend") == 0 || pars.find("backend")->second.empty())
     throw std::invalid_argument("No backend (?backend=) specified.");
 
@@ -1409,8 +1411,7 @@ double Server::getLoadStatusPercent() const {
 }
 
 // _____________________________________________________________________________
-void Server::createCache(
-                         const GeomCacheConfig& cfg) const {
+void Server::createCache(const GeomCacheConfig& cfg) const {
   std::shared_ptr<GeomCache> cache;
 
   {
@@ -1431,8 +1432,7 @@ void Server::createCache(
 }
 
 // _____________________________________________________________________________
-std::string Server::loadCache(
-                              const GeomCacheConfig& cfg) const {
+std::string Server::loadCache(const GeomCacheConfig& cfg) const {
   std::shared_ptr<GeomCache> cache = _caches[cfg.backend];
 
   try {
@@ -1545,19 +1545,27 @@ GeomCacheConfig Server::getGeomCacheCfgFromJSON(
 GeomCacheConfig Server::getGeomCacheConfig(
     const std::string& backendUrl, const std::string& accessToken,
     const std::string& configJson, const std::string& remoteAddr) const {
-
-  std::lock_guard<std::mutex> guard(_m);
-
   std::string canonizedBackend;
 
-  auto i = _canonizedURLCache.find(backendUrl);
-  if (i != _canonizedURLCache.end()) {
-    canonizedBackend = i->second;
-  } else  {
-     canonizedBackend = canonizeURL(backendUrl, remoteAddr);
-     _canonizedURLCache[backendUrl] = canonizedBackend;
+  // first check if we have it cached
+  {
+    std::lock_guard<std::mutex> guard(_m);
+    auto i = _canonizedURLCache.find(backendUrl);
+    if (i != _canonizedURLCache.end()) {
+      canonizedBackend = i->second;
+    }
   }
 
+  if (canonizedBackend.size() == 0) {
+    // if not cache, perform the canonizeURL request lock-free
+    canonizedBackend = canonizeURL(backendUrl, remoteAddr);
+
+    // only lock for writing
+    std::lock_guard<std::mutex> guard(_m);
+    _canonizedURLCache[backendUrl] = canonizedBackend;
+  }
+
+  std::lock_guard<std::mutex> guard(_m);
   auto cfg = _cacheConfigs.find(canonizedBackend);
   if (cfg != _cacheConfigs.end()) {
     if (configJson.size()) {

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -103,16 +103,20 @@ util::http::Answer Server::handle(const util::http::Req& req, int con) const {
     } else if (cmd == "/touch") {
       a = handleTouchReq(params, req.params, con);
     } else if (cmd == "/query") {
+      LOG(INFO) << "Query request from " << remoteAddress(con);
       a = handleQueryReq(params, req.params, con);
     } else if (cmd == "/geojson") {
+      LOG(INFO) << "Geojson request from " << remoteAddress(con);
       a = handleGeoJSONReq(params, con);
     } else if (cmd == "/clearsession") {
       a = handleClearSessReq(params, req.params, con);
     } else if (cmd == "/clearsessions") {
       a = handleClearSessReq(params, req.params, con);
     } else if (cmd == "/pos") {
+      LOG(INFO) << "Position request from " << remoteAddress(con);
       a = handlePosReq(params, con);
     } else if (cmd == "/export") {
+      LOG(INFO) << "Export request from " << remoteAddress(con);
       a = handleExportReq(params, con);
     } else if (cmd == "/loadstatus") {
       a = handleLoadStatusReq(params, con);

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -88,8 +88,6 @@ Server::Server(size_t maxMemory, const std::string& cacheDir, int cacheLifetime,
 
 // _____________________________________________________________________________
 util::http::Answer Server::handle(const util::http::Req& req, int con) const {
-  UNUSED(con);
-
   // ignore SIGPIPE
   signal(SIGPIPE, SIG_IGN);
 
@@ -99,25 +97,25 @@ util::http::Answer Server::handle(const util::http::Req& req, int con) const {
     auto cmd = parseUrl(req.url, req.payload, &params);
 
     if (cmd == "/") {
-      a = handleIndexReq(params);
+      a = handleIndexReq(params, con);
     } else if (cmd == "/example") {
-      a = handleExamplePageReq(params);
+      a = handleExamplePageReq(params, con);
     } else if (cmd == "/touch") {
-      a = handleTouchReq(params, req.params);
+      a = handleTouchReq(params, req.params, con);
     } else if (cmd == "/query") {
-      a = handleQueryReq(params, req.params);
+      a = handleQueryReq(params, req.params, con);
     } else if (cmd == "/geojson") {
-      a = handleGeoJSONReq(params);
+      a = handleGeoJSONReq(params, con);
     } else if (cmd == "/clearsession") {
-      a = handleClearSessReq(params, req.params);
+      a = handleClearSessReq(params, req.params, con);
     } else if (cmd == "/clearsessions") {
-      a = handleClearSessReq(params, req.params);
+      a = handleClearSessReq(params, req.params, con);
     } else if (cmd == "/pos") {
-      a = handlePosReq(params);
+      a = handlePosReq(params, con);
     } else if (cmd == "/export") {
       a = handleExportReq(params, con);
     } else if (cmd == "/loadstatus") {
-      a = handleLoadStatusReq(params);
+      a = handleLoadStatusReq(params, con);
     } else if (cmd == "/build.js") {
       a = util::http::Answer(
           "200 OK", std::string(build_js, build_js + sizeof build_js /
@@ -555,7 +553,10 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 }
 
 // _____________________________________________________________________________
-util::http::Answer Server::handleGeoJSONReq(const Params& pars) const {
+util::http::Answer Server::handleGeoJSONReq(const Params& pars,
+                                            int sock) const {
+  auto remoteAddr = remoteAddress(sock);
+
   if (pars.count("id") == 0 || pars.find("id")->second.empty())
     throw std::invalid_argument("No session id (?id=) specified.");
   auto id = pars.find("id")->second;
@@ -613,7 +614,7 @@ util::http::Answer Server::handleGeoJSONReq(const Params& pars) const {
       throw std::invalid_argument("Invalid request.");
     }
 
-    for (auto col : reqor->requestRow(row)) {
+    for (auto col : reqor->requestRow(row, remoteAddr)) {
       dict.dict[col.first] = col.second;
     }
   }
@@ -652,7 +653,9 @@ util::http::Answer Server::handleGeoJSONReq(const Params& pars) const {
 }
 
 // _____________________________________________________________________________
-util::http::Answer Server::handlePosReq(const Params& pars) const {
+util::http::Answer Server::handlePosReq(const Params& pars, int sock) const {
+  auto remoteAddr = remoteAddress(sock);
+
   if (pars.count("x") == 0 || pars.find("x")->second.empty())
     throw std::invalid_argument("No x coord (?x=) specified.");
   float x = std::atof(pars.find("x")->second.c_str());
@@ -715,7 +718,7 @@ util::http::Answer Server::handlePosReq(const Params& pars) const {
   }
   // as soon as we are ready, the reqor can be read concurrently
 
-  auto res = reqor->getNearest({x, y}, rad, reso, fbbox);
+  auto res = reqor->getNearest({x, y}, rad, reso, fbbox, remoteAddr);
 
   std::stringstream json;
 
@@ -782,8 +785,11 @@ util::http::Answer Server::handlePosReq(const Params& pars) const {
 }
 
 // _____________________________________________________________________________
-util::http::Answer Server::handleTouchReq(
-    const Params& pars, const HeaderParams& headerParams) const {
+util::http::Answer Server::handleTouchReq(const Params& pars,
+                                          const HeaderParams& headerParams,
+                                          int sock) const {
+  auto remoteAddr = remoteAddress(sock);
+
   if (pars.count("backend") == 0 || pars.find("backend")->second.empty())
     throw std::invalid_argument("No backend (?backend=) specified.");
 
@@ -800,9 +806,9 @@ util::http::Answer Server::handleTouchReq(
     configJson = pars.find("cfg")->second;
   }
 
-  auto backendCfg = getGeomCacheConfig(backend, accessToken, configJson);
+  auto backendCfg = getGeomCacheConfig(backend, accessToken, configJson, remoteAddr);
 
-  createCache(backend, backendCfg);
+  createCache(backendCfg);
   std::shared_ptr<GeomCache> cache = _caches[backend];
 
   std::stringstream ss;
@@ -818,8 +824,9 @@ util::http::Answer Server::handleTouchReq(
 }
 
 // _____________________________________________________________________________
-util::http::Answer Server::handleClearSessReq(
-    const Params& pars, const HeaderParams& headerParams) const {
+util::http::Answer Server::handleClearSessReq(const Params& pars,
+                                              const HeaderParams& headerParams,
+                                              int) const {
   std::string id;
   if (pars.count("id") != 0 && !pars.find("id")->second.empty())
     id = pars.find("id")->second;
@@ -848,7 +855,7 @@ util::http::Answer Server::handleClearSessReq(
 }
 
 // _____________________________________________________________________________
-util::http::Answer Server::handleExamplePageReq(const Params&) const {
+util::http::Answer Server::handleExamplePageReq(const Params&, int) const {
   std::string html =
       std::string(example_html,
                   example_html + sizeof example_html / sizeof example_html[0]);
@@ -860,7 +867,7 @@ util::http::Answer Server::handleExamplePageReq(const Params&) const {
 }
 
 // _____________________________________________________________________________
-util::http::Answer Server::handleIndexReq(const Params& pars) const {
+util::http::Answer Server::handleIndexReq(const Params& pars, int) const {
   std::stringstream ss;
   ss << "window.postParams =";
 
@@ -884,9 +891,11 @@ util::http::Answer Server::handleIndexReq(const Params& pars) const {
 
 // _____________________________________________________________________________
 util::http::Answer Server::handleQueryReq(const Params& pars,
-                                          const HeaderParams&) const {
+                                          const HeaderParams&, int sock) const {
   if (pars.count("backend") == 0 || pars.find("backend")->second.empty())
     throw std::invalid_argument("No backend (?backend=) specified.");
+
+  auto remoteAddr = remoteAddress(sock);
 
   RequestorConfig rcfg;
 
@@ -929,13 +938,13 @@ util::http::Answer Server::handleQueryReq(const Params& pars,
 
   const std::string& backend = pars.find("backend")->second;
 
-  auto backendCfg = getGeomCacheConfig(backend, "", "");
+  auto backendCfg = getGeomCacheConfig(backend, "", "", remoteAddr);
 
-  LOG(INFO) << "[SERVER] Queried backend is " << backend;
+  LOG(INFO) << "[SERVER] Queried backend is " << backendCfg.backend;
   LOG(INFO) << "[SERVER] Query is:\n" << rcfg.query;
 
-  createCache(backend, backendCfg);
-  std::string indexHash = loadCache(backend, backendCfg);
+  createCache(backendCfg);
+  std::string indexHash = loadCache(backendCfg);
 
   std::string queryId = backend + "$" + indexHash + "$" + rcfg.getHash();
 
@@ -960,7 +969,7 @@ util::http::Answer Server::handleQueryReq(const Params& pars,
   }
 
   try {
-    reqor->request();
+    reqor->request(remoteAddr);
   } catch (OutOfMemoryError& ex) {
     LOG(ERROR) << ex.what() << backendCfg.backend;
 
@@ -1185,6 +1194,8 @@ util::http::Answer Server::handleExportReq(const Params& pars, int sock) const {
 
   auto aw = util::http::Answer("200 OK", "");
 
+  auto remoteAddr = remoteAddress(sock);
+
   if (pars.count("id") == 0 || pars.find("id")->second.empty())
     throw std::invalid_argument("No session id (?id=) specified.");
   auto id = pars.find("id")->second;
@@ -1306,7 +1317,8 @@ util::http::Answer Server::handleExportReq(const Params& pars, int sock) const {
           }
           writes += out;
         }
-      });
+      },
+      remoteAddr);
 
   buff = "]}";
   writes = 0;
@@ -1326,15 +1338,17 @@ util::http::Answer Server::handleExportReq(const Params& pars, int sock) const {
 }
 
 // _____________________________________________________________________________
-util::http::Answer Server::handleLoadStatusReq(const Params& pars) const {
+util::http::Answer Server::handleLoadStatusReq(const Params& pars, int sock) const {
   if (pars.count("backend") == 0 || pars.find("backend")->second.empty())
     throw std::invalid_argument("No backend (?backend=) specified.");
 
+  auto remoteAddr = remoteAddress(sock);
+
   const std::string& backend = pars.find("backend")->second;
 
-  auto backendCfg = getGeomCacheConfig(backend, "", "");
+  auto backendCfg = getGeomCacheConfig(backend, "", "", remoteAddr);
 
-  createCache(backend, backendCfg);
+  createCache(backendCfg);
   std::shared_ptr<GeomCache> cache = _caches[backendCfg.backend];
 
   // We have 3 loading stages:
@@ -1395,38 +1409,38 @@ double Server::getLoadStatusPercent() const {
 }
 
 // _____________________________________________________________________________
-void Server::createCache(const std::string& backend,
+void Server::createCache(
                          const GeomCacheConfig& cfg) const {
   std::shared_ptr<GeomCache> cache;
 
   {
     std::lock_guard<std::mutex> guard(_m);
-    if (_caches.count(backend)) {
-      cache = _caches[backend];
+    if (_caches.count(cfg.backend)) {
+      cache = _caches[cfg.backend];
       // always set config
       if (cache->setConfig(cfg)) {
-        LOG(INFO) << "Updating config for backend '" << backend
+        LOG(INFO) << "Updating config for backend '" << cfg.backend
                   << "', new fill query is:\n"
                   << cfg.fillQuery;
       }
     } else {
       cache = std::shared_ptr<GeomCache>(new GeomCache(cfg, _maxMemory));
-      _caches[backend] = cache;
+      _caches[cfg.backend] = cache;
     }
   }
 }
 
 // _____________________________________________________________________________
-std::string Server::loadCache(const std::string& backend,
-                              const GeomCacheConfig&) const {
-  std::shared_ptr<GeomCache> cache = _caches[backend];
+std::string Server::loadCache(
+                              const GeomCacheConfig& cfg) const {
+  std::shared_ptr<GeomCache> cache = _caches[cfg.backend];
 
   try {
     return cache->load(_cacheDir);
   } catch (...) {
     std::lock_guard<std::mutex> guard(_m);
 
-    auto it = _caches.find(backend);
+    auto it = _caches.find(cfg.backend);
     if (it != _caches.end()) _caches.erase(it);
 
     throw;
@@ -1530,10 +1544,19 @@ GeomCacheConfig Server::getGeomCacheCfgFromJSON(
 // _____________________________________________________________________________
 GeomCacheConfig Server::getGeomCacheConfig(
     const std::string& backendUrl, const std::string& accessToken,
-    const std::string& configJson) const {
-  auto canonizedBackend = canonizeURL(backendUrl);
+    const std::string& configJson, const std::string& remoteAddr) const {
 
   std::lock_guard<std::mutex> guard(_m);
+
+  std::string canonizedBackend;
+
+  auto i = _canonizedURLCache.find(backendUrl);
+  if (i != _canonizedURLCache.end()) {
+    canonizedBackend = i->second;
+  } else  {
+     canonizedBackend = canonizeURL(backendUrl, remoteAddr);
+     _canonizedURLCache[backendUrl] = canonizedBackend;
+  }
 
   auto cfg = _cacheConfigs.find(canonizedBackend);
   if (cfg != _cacheConfigs.end()) {

--- a/src/qlever-petrimaps/server/Server.h
+++ b/src/qlever-petrimaps/server/Server.h
@@ -37,26 +37,27 @@ class Server : public util::http::Handler {
  private:
   static std::string parseUrl(std::string u, std::string pl, Params* params);
 
-  util::http::Answer handleIndexReq(const Params& pars) const;
-  util::http::Answer handleExamplePageReq(const Params& pars) const;
+  util::http::Answer handleIndexReq(const Params& pars, int sock) const;
+  util::http::Answer handleExamplePageReq(const Params& pars, int sock) const;
   util::http::Answer handleTouchReq(const Params& pars,
-                                    const HeaderParams& headerPars) const;
+                                    const HeaderParams& headerPars,
+                                    int sock) const;
   util::http::Answer handleHeatMapReq(const Params& pars, int sock) const;
   util::http::Answer handleQueryReq(const Params& pars,
-                                    const HeaderParams& headerPars) const;
-  util::http::Answer handleGeoJSONReq(const Params& pars) const;
+                                    const HeaderParams& headerPars,
+                                    int sock) const;
+  util::http::Answer handleGeoJSONReq(const Params& pars, int sock) const;
   util::http::Answer handleClearSessReq(const Params& pars,
-                                        const HeaderParams& headerPars) const;
-  util::http::Answer handlePosReq(const Params& pars) const;
-  util::http::Answer handleLoadReq(const Params& pars) const;
+                                        const HeaderParams& headerPars,
+                                        int sock) const;
+  util::http::Answer handlePosReq(const Params& pars, int sock) const;
+  util::http::Answer handleLoadReq(const Params& pars, int sock) const;
 
   util::http::Answer handleExportReq(const Params& pars, int sock) const;
-  util::http::Answer handleLoadStatusReq(const Params& pars) const;
+  util::http::Answer handleLoadStatusReq(const Params& pars, int sock) const;
 
-  void createCache(const std::string& backend,
-                   const GeomCacheConfig& cfg) const;
-  std::string loadCache(const std::string& backend,
-                        const GeomCacheConfig& cfg) const;
+  void createCache(const GeomCacheConfig& cfg) const;
+  std::string loadCache(const GeomCacheConfig& cfg) const;
 
   void clearSession(const std::string& id) const;
   void clearSessions() const;
@@ -69,7 +70,8 @@ class Server : public util::http::Handler {
 
   GeomCacheConfig getGeomCacheConfig(const std::string& backendUrl,
                                      const std::string& access,
-                                     const std::string& configJson) const;
+                                     const std::string& configJson,
+                                     const std::string& remoteAddr) const;
   RequestorConfig getRequestorCfgFromJSON(const std::string& json) const;
   GeomCacheConfig getGeomCacheCfgFromJSON(const std::string& backend,
                                           const std::string& json) const;
@@ -106,6 +108,8 @@ class Server : public util::http::Handler {
   mutable std::map<std::string, std::shared_ptr<GeomCache>> _caches;
   mutable std::map<std::string, std::shared_ptr<Requestor>> _rs;
   mutable std::map<std::string, std::string> _queryCache;
+
+  mutable std::map<std::string, std::string> _canonizedURLCache;
 
   mutable std::map<std::string, GeomCacheConfig> _cacheConfigs;
   std::string _accessToken;


### PR DESCRIPTION
For each request to QLever that originated from a user interaction (*not* the cache-fill related requests), set the `X-Real-IP` header to the remote address. This allows rate limiting on the Qlever side. We cannot limit on the raw connection address, because each request is from the same IP (the server running petrimaps).

On the side:

* Abstract away all `libcurl` calls to QLever into a single `performCurlRequest` method.
* Fix a nasty problem with the new `canonizeURL()` functionality which fully resolves backend URLs to disambiguate QLever backend URLs (like `qlever.dev` vs. `qlever.cs.uni-freiburg.de`): previously, each `/loadstatus` request triggered a `canonizeURL()`, which itself triggered a call to the QLever server to resolve any redirects. The canonized URL is now cached and re-used.