### PR TITLE
More object styling options, avoid double geometry bookkeeping

### DIFF
--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -1043,7 +1043,7 @@ void GeomCache::serializeToDisk(const std::string &fname) const {
   std::ofstream f;
   f.open(fname, std::ios::binary);
 
-  std::string h = _indexHash;
+  std::string h = _indexHash.substr(0, 99);
   h.insert(h.end(), 99 - h.size(), ' ');
 
   // null byte is 100

--- a/src/qlever-petrimaps/GeomCache.h
+++ b/src/qlever-petrimaps/GeomCache.h
@@ -221,7 +221,7 @@ class GeomCache {
 
   static std::vector<size_t> getGeomStarts(const std::string& str, size_t a);
 
-  static util::geo::DPoint projD(const util::geo::DPoint& p) {
+  static util::geo::DPoint projD(const util::geo::DPoint& p, const util::geo::CRSType&) {
     return util::geo::latLngToWebMerc<double>(p);
   }
 

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -321,12 +321,12 @@ void RequestReader::parse(const char* c, size_t size) {
         }
       case IN_ROW:
         if (*c == '\t' || *c == '\n') {
-          curCols.push_back({_colNames[_curCol], _dangling});
+          _curCols.push_back({_colNames[_curCol], _dangling});
 
           if (*c == '\n') {
             _curRow++;
-            rows.push_back(curCols);
-            curCols = {};
+            _rows.push_back(_curCols);
+            _curCols = {};
             _curCol = 0;
           } else {
             _curCol++;

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -220,8 +220,8 @@ struct RequestReader {
 
   ParseState _state = IN_HEADER;
 
-  std::vector<std::vector<std::pair<std::string, std::string>>> rows;
-  std::vector<std::pair<std::string, std::string>> curCols;
+  std::vector<std::vector<std::pair<std::string, std::string>>> _rows;
+  std::vector<std::pair<std::string, std::string>> _curCols;
 
   uint8_t _curByte = 0;
   size_t _curIdCol = 0;

--- a/src/qlever-petrimaps/PetriMapsMain.cpp
+++ b/src/qlever-petrimaps/PetriMapsMain.cpp
@@ -168,7 +168,8 @@ int main(int argc, char** argv) {
     Server serv(maxMemoryGB * 1000000000, cacheDir, cacheLifetime,
                 autoThreshold, geomCacheConfigs, accessToken);
 
-    LOG(INFO) << "Listening on port " << port;
+    LOG(INFO) << "Listening on port " << port
+              << " (open http://localhost:9090/example)";
     util::http::HttpServer(port, &serv, std::thread::hardware_concurrency())
         .run();
   } catch (const std::runtime_error& e) {

--- a/src/qlever-petrimaps/server/RenderContext.cpp
+++ b/src/qlever-petrimaps/server/RenderContext.cpp
@@ -107,12 +107,13 @@ void RenderContext::drawPointObject(size_t tid, int px, int py, double weight,
 void RenderContext::drawLinePoint(size_t tid, int px, int py, double weight,
                                   double rasterW, double rasterH) {
   drawPoint(tid, px, py, weight, rasterW, rasterH,
-            (_ostyle.lineWidth * 1.0) / 2.0);
+            (_ostyle.lineWidth - 1) / 2.0);
 }
 
 // _____________________________________________________________________________
 void RenderContext::drawPoint(size_t tid, int px, int py, double weight,
                               double rasterW, double rasterH, double r) {
+  if (r < 0) return;
   if (_style == RASTER) {
     if (px >= 0 && py >= 0 && px < _w && py < _h) {
       _rasterDims[tid][_w * py + px] = {rasterW, rasterH};
@@ -127,16 +128,20 @@ void RenderContext::drawPoint(size_t tid, int px, int py, double weight,
       }
     }
   } else if (_style == OBJECTS) {
-    const int ri = std::ceil(r + 1);
-    for (int y = std::max(0, py - ri); y <= std::min(_h - 1, py + ri); y++) {
-      const int dy = y - py;
-      for (int x = std::max(0, px - ri); x <= std::min(_w - 1, px + ri); x++) {
-        const int dx = x - px;
-        const double cov =
-            std::min(1.0, r + 1 - std::sqrt(1.0 * dx * dx + 1.0 * dy * dy));
-        if (cov <= 0) continue;
-        if (_weights[tid][_w * y + x] == 0) _points[tid].push_back(_w * y + x);
-        _weights[tid][_w * y + x] = std::max(_weights[tid][_w * y + x], cov);
+    if (px >= 0 && py >= 0 && px < _w && py < _h) {
+      if (abs(ceil(r) - r) > 0.1) {
+        if (px + 1 < _w && _weights[tid][_w * py + px + 1] == 0) {
+          _points[tid].push_back(_w * py + px + 1);
+          _weights[tid][_w * py + px + 1] = 1;
+        }
+        if (py >= 1 && _weights[tid][_w * (py - 1) + px] == 0) {
+          _points[tid].push_back(_w * (py - 1) + px);
+          _weights[tid][_w * (py - 1) + px] = 1;
+        }
+      }
+      if (_weights[tid][_w * py + px] == 0) {
+        _points[tid].push_back(_w * py + px);
+        _weights[tid][_w * py + px] = 1;
       }
     }
   } else {
@@ -171,8 +176,8 @@ void RenderContext::drawArea(size_t tid, const util::geo::DLine& line,
   }
 
   if (border) {
-    const auto& denseline =
-        util::geo::densify(pxPoly.getOuter(), (_ostyle.lineWidth * 1.0) / 2.0);
+    const auto& denseline = util::geo::densify(
+        pxPoly.getOuter(), std::max(0.5, (_ostyle.lineWidth * 1.0) / 2.0));
     for (const auto& p : denseline) {
       drawLinePoint(tid, p.getX(), p.getY(), val, 1, 1);
     }
@@ -276,25 +281,18 @@ void RenderContext::writeHeatmap(heatmap_t* hm) {
 
     for (auto stamp : stamps) heatmap_stamp_free(stamp.second);
   } else if (_style == OBJECTS) {
-    std::vector<double> cov(_w * _h, 0);
-    std::vector<uint32_t> covPoints;
-
-    for (size_t i = 0; i < NUM_THREADS; i++) {
-      for (const auto& p : _points[i]) {
-        if (cov[p] == 0) covPoints.push_back(p);
-        cov[p] = std::max(cov[p], _weights[i][p]);
+    if ((_ostyle.lineWidth - 1.0) / 2.0 >= 0) {
+      int r = (_ostyle.lineWidth - 1.0) / 2.0;
+      auto stamp = heatmap_stamp_gen(r);
+      for (size_t i = 0; i < NUM_THREADS; i++) {
+        for (const auto& p : _points[i]) {
+          size_t y = p / _w;
+          size_t x = p - (y * _w);
+          heatmap_add_weighted_point_with_stamp(hm, x, y, 1, stamp);
+        }
       }
+      heatmap_stamp_free(stamp);
     }
-
-    auto stamp = heatmap_stamp_gen(0);
-    for (const auto& p : covPoints) {
-      size_t y = p / _w;
-      size_t x = p - (y * _w);
-      // clamped to the saturation used when rendering
-      heatmap_add_weighted_point_with_stamp(hm, x, y, std::min(1.0, cov[p]),
-                                            stamp);
-    }
-    heatmap_stamp_free(stamp);
   } else {
     // HEATMAP
     for (size_t i = 0; i < NUM_THREADS; i++) {

--- a/src/qlever-petrimaps/server/RenderContext.cpp
+++ b/src/qlever-petrimaps/server/RenderContext.cpp
@@ -32,7 +32,8 @@ using petrimaps::RenderContext;
 
 // _____________________________________________________________________________
 RenderContext::RenderContext(int w, int h, double orx, double ory, double mercW,
-                             double mercH, MapStyle style, size_t numThreads)
+                             double mercH, MapStyle style, ObjectStyle ostyle,
+                             size_t numThreads)
     : _points(numThreads),
       _areaFillPoints(numThreads),
       _weights(numThreads),
@@ -40,6 +41,7 @@ RenderContext::RenderContext(int w, int h, double orx, double ory, double mercW,
       _rasterDims(numThreads),
       _image(w * h * 4),
       _style(style),
+      _ostyle(ostyle),
       _w(w),
       _h(h),
       _orx(orx),
@@ -96,8 +98,21 @@ void RenderContext::writeInteriorObjects(heatmap_t* hm) {
 }
 
 // _____________________________________________________________________________
+void RenderContext::drawPointObject(size_t tid, int px, int py, double weight,
+                                    double rasterW, double rasterH) {
+  drawPoint(tid, px, py, weight, rasterW, rasterH, _ostyle.pointRadius);
+}
+
+// _____________________________________________________________________________
+void RenderContext::drawLinePoint(size_t tid, int px, int py, double weight,
+                                  double rasterW, double rasterH) {
+  drawPoint(tid, px, py, weight, rasterW, rasterH,
+            (_ostyle.lineWidth * 1.0) / 2.0);
+}
+
+// _____________________________________________________________________________
 void RenderContext::drawPoint(size_t tid, int px, int py, double weight,
-                              double rasterW, double rasterH, int r) {
+                              double rasterW, double rasterH, double r) {
   if (_style == RASTER) {
     if (px >= 0 && py >= 0 && px < _w && py < _h) {
       _rasterDims[tid][_w * py + px] = {rasterW, rasterH};
@@ -112,13 +127,16 @@ void RenderContext::drawPoint(size_t tid, int px, int py, double weight,
       }
     }
   } else if (_style == OBJECTS) {
-    for (int x = px - r; x <= px + r; x++) {
-      for (int y = py - r; y <= py + r; y++) {
-        if (x >= 0 && y >= 0 && x < _w && y < _h) {
-          if (_weights[tid][_w * y + x] == 0)
-            _points[tid].push_back(_w * y + x);
-          _weights[tid][_w * y + x] += weight;
-        }
+    const int ri = std::ceil(r + 1);
+    for (int y = std::max(0, py - ri); y <= std::min(_h - 1, py + ri); y++) {
+      const int dy = y - py;
+      for (int x = std::max(0, px - ri); x <= std::min(_w - 1, px + ri); x++) {
+        const int dx = x - px;
+        const double cov =
+            std::min(1.0, r + 1 - std::sqrt(1.0 * dx * dx + 1.0 * dy * dy));
+        if (cov <= 0) continue;
+        if (_weights[tid][_w * y + x] == 0) _points[tid].push_back(_w * y + x);
+        _weights[tid][_w * y + x] = std::max(_weights[tid][_w * y + x], cov);
       }
     }
   } else {
@@ -153,9 +171,10 @@ void RenderContext::drawArea(size_t tid, const util::geo::DLine& line,
   }
 
   if (border) {
-    const auto& denseline = util::geo::densify(pxPoly.getOuter(), .5);
+    const auto& denseline =
+        util::geo::densify(pxPoly.getOuter(), (_ostyle.lineWidth * 1.0) / 2.0);
     for (const auto& p : denseline) {
-      drawPoint(tid, p.getX(), p.getY(), val, 1, 1, 0);
+      drawLinePoint(tid, p.getX(), p.getY(), val, 1, 1);
     }
   }
 
@@ -169,8 +188,8 @@ void RenderContext::drawArea(size_t tid, const util::geo::DLine& line,
   minX = std::max(minX, 0);
   maxX = std::min(maxX, static_cast<int>(_w) - 1);
 
-  auto fillPoints = fill(pxPoly, 1,
-                                util::geo::IBox({minX, minY}, {maxX, maxY}));
+  auto fillPoints =
+      fill(pxPoly, 1, util::geo::IBox({minX, minY}, {maxX, maxY}));
 
   for (const auto& o : fillPoints) {
     // negative fill value for inners to punch them out
@@ -186,7 +205,7 @@ void RenderContext::drawLine(size_t tid, const util::geo::DLine& line,
 
   for (const auto& p : denseline) {
     auto pix = mercToPx(p, _orx, _ory, _mercW, _mercH, _w, _h);
-    drawPoint(tid, pix.getX(), pix.getY(), val, 1, 1, 0);
+    drawLinePoint(tid, pix.getX(), pix.getY(), val, 1, 1);
   }
 }
 
@@ -257,13 +276,23 @@ void RenderContext::writeHeatmap(heatmap_t* hm) {
 
     for (auto stamp : stamps) heatmap_stamp_free(stamp.second);
   } else if (_style == OBJECTS) {
-    auto stamp = heatmap_stamp_gen(1);
+    std::vector<double> cov(_w * _h, 0);
+    std::vector<uint32_t> covPoints;
+
     for (size_t i = 0; i < NUM_THREADS; i++) {
       for (const auto& p : _points[i]) {
-        size_t y = p / _w;
-        size_t x = p - (y * _w);
-        heatmap_add_weighted_point_with_stamp(hm, x, y, 1, stamp);
+        if (cov[p] == 0) covPoints.push_back(p);
+        cov[p] = std::max(cov[p], _weights[i][p]);
       }
+    }
+
+    auto stamp = heatmap_stamp_gen(0);
+    for (const auto& p : covPoints) {
+      size_t y = p / _w;
+      size_t x = p - (y * _w);
+      // clamped to the saturation used when rendering
+      heatmap_add_weighted_point_with_stamp(hm, x, y, std::min(1.0, cov[p]),
+                                            stamp);
     }
     heatmap_stamp_free(stamp);
   } else {

--- a/src/qlever-petrimaps/server/RenderContext.cpp
+++ b/src/qlever-petrimaps/server/RenderContext.cpp
@@ -36,8 +36,10 @@ RenderContext::RenderContext(int w, int h, double orx, double ory, double mercW,
                              size_t numThreads)
     : _points(numThreads),
       _areaFillPoints(numThreads),
+      _linePoints(numThreads),
       _weights(numThreads),
       _areaFillWeights(numThreads),
+      _lineWeights(numThreads),
       _rasterDims(numThreads),
       _image(w * h * 4),
       _style(style),
@@ -52,6 +54,7 @@ RenderContext::RenderContext(int w, int h, double orx, double ory, double mercW,
     _rasterDims[i].resize(w * h, {1, 1});
     _weights[i].resize(w * h, 0);
     _areaFillWeights[i].resize(w * h, 0);
+    _lineWeights[i].resize(w * h, 0);
   }
 }
 
@@ -98,22 +101,46 @@ void RenderContext::writeInteriorObjects(heatmap_t* hm) {
 }
 
 // _____________________________________________________________________________
-void RenderContext::drawPointObject(size_t tid, int px, int py, double weight,
-                                    double rasterW, double rasterH) {
-  drawPoint(tid, px, py, weight, rasterW, rasterH, _ostyle.pointRadius);
+void RenderContext::drawLinePoint(size_t tid, int px, int py, double weight,
+                                  double rasterW, double rasterH) {
+  drawLinePoint(tid, px, py, weight, rasterW, rasterH,
+                (_ostyle.lineWidth - 1) / 2.0);
 }
 
 // _____________________________________________________________________________
 void RenderContext::drawLinePoint(size_t tid, int px, int py, double weight,
-                                  double rasterW, double rasterH) {
-  drawPoint(tid, px, py, weight, rasterW, rasterH,
-            (_ostyle.lineWidth - 1) / 2.0);
+                                  double, double, double r) {
+  if (r < 0) return;
+  if (_style == OBJECTS) {
+    if (px >= 0 && py >= 0 && px < _w && py < _h) {
+      if (abs(ceil(r) - r) > 0.1) {
+        if (px + 1 < _w && py + 1 < _h &&
+            _lineWeights[tid][_w * (py + 1) + px + 1] == 0) {
+          _linePoints[tid].push_back(_w * (py + 1) + px + 1);
+          _lineWeights[tid][_w * (py + 1) + px + 1] = 1;
+        }
+        if (py + 1 < _h && _lineWeights[tid][_w * (py + 1) + px] == 0) {
+          _linePoints[tid].push_back(_w * (py + 1) + px);
+          _lineWeights[tid][_w * (py + 1) + px] = 1;
+        }
+      }
+      if (_lineWeights[tid][_w * py + px] == 0) {
+        _linePoints[tid].push_back(_w * py + px);
+        _lineWeights[tid][_w * py + px] = 1;
+      }
+    }
+  } else {
+    if (px >= 0 && py >= 0 && px < _w && py < _h) {
+      if (_lineWeights[tid][_w * py + px] == 0)
+        _linePoints[tid].push_back(_w * py + px);
+      _lineWeights[tid][_w * py + px] += weight;
+    }
+  }
 }
 
 // _____________________________________________________________________________
 void RenderContext::drawPoint(size_t tid, int px, int py, double weight,
-                              double rasterW, double rasterH, double r) {
-  if (r < 0) return;
+                              double rasterW, double rasterH) {
   if (_style == RASTER) {
     if (px >= 0 && py >= 0 && px < _w && py < _h) {
       _rasterDims[tid][_w * py + px] = {rasterW, rasterH};
@@ -129,20 +156,9 @@ void RenderContext::drawPoint(size_t tid, int px, int py, double weight,
     }
   } else if (_style == OBJECTS) {
     if (px >= 0 && py >= 0 && px < _w && py < _h) {
-      if (abs(ceil(r) - r) > 0.1) {
-        if (px + 1 < _w && _weights[tid][_w * py + px + 1] == 0) {
-          _points[tid].push_back(_w * py + px + 1);
-          _weights[tid][_w * py + px + 1] = 1;
-        }
-        if (py >= 1 && _weights[tid][_w * (py - 1) + px] == 0) {
-          _points[tid].push_back(_w * (py - 1) + px);
-          _weights[tid][_w * (py - 1) + px] = 1;
-        }
-      }
-      if (_weights[tid][_w * py + px] == 0) {
+      if (_weights[tid][_w * py + px] == 0)
         _points[tid].push_back(_w * py + px);
-        _weights[tid][_w * py + px] = 1;
-      }
+      _weights[tid][_w * py + px] = 1;
     }
   } else {
     if (px >= 0 && py >= 0 && px < _w && py < _h) {
@@ -176,8 +192,10 @@ void RenderContext::drawArea(size_t tid, const util::geo::DLine& line,
   }
 
   if (border) {
-    const auto& denseline = util::geo::densify(
-        pxPoly.getOuter(), std::max(0.5, (_ostyle.lineWidth * 1.0) / 2.0));
+    const auto& denseline = util::geo::sparseify(
+        util::geo::densify(pxPoly.getOuter(),
+                           std::max(0.5, (_ostyle.lineWidth * 1.0) / 4.0)),
+        (_ostyle.lineWidth * 1.0) / 10.0);
     for (const auto& p : denseline) {
       drawLinePoint(tid, p.getX(), p.getY(), val, 1, 1);
     }
@@ -283,7 +301,19 @@ void RenderContext::writeHeatmap(heatmap_t* hm) {
   } else if (_style == OBJECTS) {
     if ((_ostyle.lineWidth - 1.0) / 2.0 >= 0) {
       int r = (_ostyle.lineWidth - 1.0) / 2.0;
+
       auto stamp = heatmap_stamp_gen(r);
+      for (size_t i = 0; i < NUM_THREADS; i++) {
+        for (const auto& p : _linePoints[i]) {
+          size_t y = p / _w;
+          size_t x = p - (y * _w);
+          heatmap_add_weighted_point_with_stamp(hm, x, y, 1, stamp);
+        }
+      }
+      heatmap_stamp_free(stamp);
+
+      // points
+      stamp = heatmap_stamp_gen(_ostyle.pointRadius);
       for (size_t i = 0; i < NUM_THREADS; i++) {
         for (const auto& p : _points[i]) {
           size_t y = p / _w;
@@ -291,7 +321,6 @@ void RenderContext::writeHeatmap(heatmap_t* hm) {
           heatmap_add_weighted_point_with_stamp(hm, x, y, 1, stamp);
         }
       }
-      heatmap_stamp_free(stamp);
     }
   } else {
     // HEATMAP
@@ -301,6 +330,15 @@ void RenderContext::writeHeatmap(heatmap_t* hm) {
         size_t x = p - (y * _w);
         if (_weights[i][p] > 0)
           heatmap_add_weighted_point(hm, x, y, _weights[i][p]);
+      }
+    }
+
+    for (size_t i = 0; i < NUM_THREADS; i++) {
+      for (const auto& p : _linePoints[i]) {
+        size_t y = p / _w;
+        size_t x = p - (y * _w);
+        if (_lineWeights[i][p] > 0)
+          heatmap_add_weighted_point(hm, x, y, _lineWeights[i][p]);
       }
     }
 

--- a/src/qlever-petrimaps/server/RenderContext.h
+++ b/src/qlever-petrimaps/server/RenderContext.h
@@ -17,10 +17,17 @@ namespace petrimaps {
 
 enum MapStyle { HEATMAP, OBJECTS, RASTER };
 
+struct ObjectStyle {
+  double pointRadius;
+  double lineWidth;
+  double fillOpacity;
+  double lineOpacity;
+};
+
 class RenderContext {
  public:
   RenderContext(int w, int h, double orx, double ory, double mercW,
-                double mercH, MapStyle style, size_t numThreads);
+                double mercH, MapStyle style, ObjectStyle ostyle, size_t numThreads);
 
   const std::vector<uint32_t>& getPoints(size_t i) { return _points[i]; }
   const std::vector<uint32_t>& getAreaFillPoints(size_t i) {
@@ -30,8 +37,12 @@ class RenderContext {
     return _rasterDims[i];
   }
   std::vector<unsigned char>& getImage() { return _image; }
+  void drawLinePoint(size_t tid, int px, int py, double weight, double rasterW,
+                 double rasterH);
   void drawPoint(size_t tid, int px, int py, double weight, double rasterW,
-                 double rasterH, int r = 1);
+                 double rasterH, double r = 1);
+  void drawPointObject(size_t tid, int px, int py, double weight, double rasterW,
+                 double rasterH);
   void drawFillPoint(size_t tid, int px, int py, double weight, int r = 0);
   void drawLineSegment(int x0, int y0, int x1, int y1, int w, int h);
   void drawLine(size_t tid, const util::geo::DLine& line, double val);
@@ -62,6 +73,7 @@ class RenderContext {
   std::vector<std::vector<std::pair<float, float>>> _rasterDims;
   std::vector<unsigned char> _image;
   MapStyle _style;
+  ObjectStyle _ostyle;
 
   int _w, _h;
   double _orx, _ory, _mercW, _mercH;

--- a/src/qlever-petrimaps/server/RenderContext.h
+++ b/src/qlever-petrimaps/server/RenderContext.h
@@ -18,10 +18,10 @@ namespace petrimaps {
 enum MapStyle { HEATMAP, OBJECTS, RASTER };
 
 struct ObjectStyle {
-  double pointRadius;
-  double lineWidth;
-  double fillOpacity;
-  double lineOpacity;
+  double pointRadius = 3;
+  double lineWidth = 2;
+  double fillOpacity = .5;
+  double lineOpacity = 1;
 };
 
 class RenderContext {

--- a/src/qlever-petrimaps/server/RenderContext.h
+++ b/src/qlever-petrimaps/server/RenderContext.h
@@ -19,7 +19,7 @@ enum MapStyle { HEATMAP, OBJECTS, RASTER };
 
 struct ObjectStyle {
   double pointRadius = 3;
-  double lineWidth = 2;
+  double lineWidth = 3;
   double fillOpacity = .5;
   double lineOpacity = 1;
 };
@@ -27,9 +27,13 @@ struct ObjectStyle {
 class RenderContext {
  public:
   RenderContext(int w, int h, double orx, double ory, double mercW,
-                double mercH, MapStyle style, ObjectStyle ostyle, size_t numThreads);
+                double mercH, MapStyle style, ObjectStyle ostyle,
+                size_t numThreads);
 
   const std::vector<uint32_t>& getPoints(size_t i) { return _points[i]; }
+  const std::vector<uint32_t>& getLinePoints(size_t i) {
+    return _linePoints[i];
+  }
   const std::vector<uint32_t>& getAreaFillPoints(size_t i) {
     return _areaFillPoints[i];
   }
@@ -38,10 +42,10 @@ class RenderContext {
   }
   std::vector<unsigned char>& getImage() { return _image; }
   void drawLinePoint(size_t tid, int px, int py, double weight, double rasterW,
-                 double rasterH);
+                     double rasterH, double rad);
+  void drawLinePoint(size_t tid, int px, int py, double weight, double rasterW,
+                     double rasterH);
   void drawPoint(size_t tid, int px, int py, double weight, double rasterW,
-                 double rasterH, double r = 1);
-  void drawPointObject(size_t tid, int px, int py, double weight, double rasterW,
                  double rasterH);
   void drawFillPoint(size_t tid, int px, int py, double weight, int r = 0);
   void drawLineSegment(int x0, int y0, int x1, int y1, int w, int h);
@@ -68,8 +72,10 @@ class RenderContext {
 
   std::vector<std::vector<uint32_t>> _points;
   std::vector<std::vector<uint32_t>> _areaFillPoints;
+  std::vector<std::vector<uint32_t>> _linePoints;
   std::vector<std::vector<double>> _weights;
   std::vector<std::vector<double>> _areaFillWeights;
+  std::vector<std::vector<double>> _lineWeights;
   std::vector<std::vector<std::pair<float, float>>> _rasterDims;
   std::vector<unsigned char> _image;
   MapStyle _style;

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -405,7 +405,8 @@ void Requestor::request(const std::string& remoteAddr) {
                   (mainY * M_COORD_GRANULARITY + cur.getY()) / 10.0);
 
               if (lineIsArea && gi != 3) {
-                area += (lastP.getX() + curP.getX()) * (lastP.getY() - curP.getY());
+                area +=
+                    (lastP.getX() + curP.getX()) * (lastP.getY() - curP.getY());
                 fbox = extendBox(curP, fbox);
               }
 
@@ -510,7 +511,8 @@ void Requestor::requestRows(
 }
 
 // _____________________________________________________________________________
-std::vector<std::string> Requestor::getColumns(std::string query) const {
+std::vector<std::string> Requestor::getColumns(const std::string& backend,
+                                               std::string query) {
   std::regex expr("select[^{]*(\\*|[\\?$][A-Z0-9_\\-+]*)+[^{]*\\s*\\{",
                   std::regex_constants::icase);
 
@@ -520,7 +522,7 @@ std::vector<std::string> Requestor::getColumns(std::string query) const {
 
   query += " LIMIT 0";
 
-  RequestReader reader(_cache->getConfig().backend, _maxMemory, 0, 0, 0);
+  RequestReader reader(backend, -1, 0, 0, 0);
   return reader.requestColumns(query);
 }
 

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -583,18 +583,6 @@ std::string Requestor::prepQueryRow(std::string query, uint64_t row) const {
 }
 
 // _____________________________________________________________________________
-const ResObj Requestor::getNearest(util::geo::DPoint rp, double rad, double res,
-                                   util::geo::FBox fullbox,
-                                   const std::string& remoteAddr) const {
-  for (size_t lid = 0; lid < getNumLayers(); lid++) {
-    auto r = getNearest(lid, rp, rad, res, fullbox, remoteAddr);
-    if (r.has) return r;
-  }
-
-  return {false, 0, 0, {0, 0}, {}, {}, {}, {}};
-}
-
-// _____________________________________________________________________________
 const ResObj Requestor::getNearest(size_t lid, util::geo::DPoint rp, double rad,
                                    double res, util::geo::FBox fullbox,
                                    const std::string& remoteAddr) const {
@@ -1082,7 +1070,6 @@ util::geo::DPoint Requestor::clusterGeom(size_t lid, size_t oid,
     return util::geo::DPoint{x, y};
   }
 }
-
 // _____________________________________________________________________________
 bool Requestor::lineIntersects(size_t lineId,
                                const util::geo::DBox& bbox) const {
@@ -1145,23 +1132,23 @@ std::pair<double, double> Requestor::getValRange(size_t lid) const {
 
 // _____________________________________________________________________________
 std::pair<double, double> Requestor::getRasterMetas(
-    size_t lid, size_t oid, std::pair<double, double> def) const {
+    size_t lid, size_t oid) const {
   const size_t gid = _lidToObject[lid];
   const size_t rid = _lidToRaster[lid];
 
-  if (rid == NO_COL) return def;
+  if (rid == NO_COL) return {10, 10};
 
   const auto& rasterMetas = _rasterMetas[rid];
 
   if (oid < _objects[gid].size()) {
-    if (_objects[gid][oid].second >= rasterMetas.size()) return def;
+    if (_objects[gid][oid].second >= rasterMetas.size()) return {10, 10};
     return _cache->getRasterMeta(rasterMetas[_objects[gid][oid].second]);
   }
 
   // dynamic points
   const size_t did = oid - _objects[gid].size();
-  if (did >= _dynamicPoints[gid].size()) return def;
-  if (_dynamicPoints[gid][did].second >= rasterMetas.size()) return def;
+  if (did >= _dynamicPoints[gid].size()) return {10, 10};
+  if (_dynamicPoints[gid][did].second >= rasterMetas.size()) return {10, 10};
   return _cache->getRasterMeta(rasterMetas[_dynamicPoints[gid][did].second]);
 }
 

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -505,9 +505,9 @@ std::vector<std::pair<std::string, std::string>> Requestor::requestRow(
 
   reader.requestRows(query, remoteAddr);
 
-  if (reader.rows.size() == 0) return {};
+  if (reader._rows.size() == 0) return {};
 
-  return reader.rows[0];
+  return reader._rows[0];
 }
 
 // _____________________________________________________________________________
@@ -526,9 +526,9 @@ void Requestor::requestRows(
       _rcfg.query,
       [&reader, &cb](const char* c, size_t n) {
         // parse this block of rows and give them to the callback
-        reader.rows = {};
+        reader._rows = {};
         reader.parse(c, n);
-        cb(reader.rows);
+        cb(reader._rows);
       },
       remoteAddr);
 }
@@ -666,80 +666,26 @@ const ResObj Requestor::getNearest(size_t lid, util::geo::DPoint rp, double rad,
 #pragma omp parallel for num_threads(NUM_THREADS) schedule(static)
       for (size_t idx = 0; idx < retL.size(); idx++) {
         const auto& oid = retL[idx];
-        auto lBox = _cache->getLineBBox(_objects[gid][oid].first - I_OFFSET);
-        if (!util::geo::intersects(lBox, box)) continue;
+        const size_t geometryId = _objects[lid][oid].first - I_OFFSET;
+        const auto lBox = _cache->getLineBBox(geometryId);
 
-        size_t start = _cache->getLine(_objects[gid][oid].first - I_OFFSET);
-        size_t end = _cache->getLineEnd(_objects[gid][oid].first - I_OFFSET);
-
-        // TODO _____________________ own function
-        double d = std::numeric_limits<double>::infinity();
-
-        util::geo::DPoint curPa, curPb;
-        int s = 0;
-
-        size_t gi = 0;
-
-        double mainX = 0;
-        double mainY = 0;
-
-        bool isArea = Requestor::isArea(_objects[gid][oid].first - I_OFFSET);
-
-        util::geo::DLine areaBorder;
-
-        for (size_t i = start; i < end; i++) {
-          // extract real geom
-          const auto& cur = _cache->getLinePoints()[i];
-
-          if (isMCoord(cur.getX())) {
-            mainX = rmCoord(cur.getX());
-            mainY = rmCoord(cur.getY());
-            continue;
-          }
-
-          // skip bounding box at beginning
-          gi++;
-          if (gi < 3) continue;
-
-          // extract real geometry
-          util::geo::DPoint curP(
-              (mainX * M_COORD_GRANULARITY + cur.getX()) / 10.0,
-              (mainY * M_COORD_GRANULARITY + cur.getY()) / 10.0);
-
-          if (isArea) areaBorder.push_back(curP);
-
-          if (s == 0) {
-            curPa = curP;
-            s++;
-          } else if (s == 1) {
-            curPb = curP;
-            s++;
-          }
-
-          if (s == 2) {
-            s = 1;
-            double dTmp = util::geo::distToSegment(curPa, curPb, rp);
-            if (dTmp < 0.0001) {
-              d = 0;
-              break;
-            }
-            curPa = curPb;
-            if (dTmp < d) d = dTmp;
-          }
-        }
-        // TODO _____________________ own function
-
-        if (isArea) {
-          if (util::geo::contains(rp, util::geo::DPolygon(areaBorder))) {
-            // set it to rad/4 - this allows selecting smaller objects
-            // inside the polgon
-            d = rad / 4;
-          }
+        if (!util::geo::intersects(lBox, box)) {
+          continue;
         }
 
-        if (d < dBestLVec[omp_get_thread_num()]) {
-          nearestLVec[omp_get_thread_num()] = oid;
-          dBestLVec[omp_get_thread_num()] = d;
+        double distance;
+
+        if (isArea(geometryId)) {
+          distance = getPolygonDistance(geometryId, rp, rad);
+        } else {
+          distance = getLineDistance(geometryId, rp);
+        }
+
+        const auto threadId = omp_get_thread_num();
+
+        if (distance < dBestLVec[threadId]) {
+          nearestLVec[threadId] = oid;
+          dBestLVec[threadId] = distance;
         }
       }
     }
@@ -877,7 +823,71 @@ bool Requestor::isInnerArea(size_t lineId) const {
 }
 
 // _____________________________________________________________________________
-util::geo::MultiLine<double> Requestor::geomLineGeoms(size_t lid, size_t oid,
+double Requestor::getLineDistance(
+    size_t lineId,
+    const util::geo::DPoint& queryPoint) const {
+  const auto line = extractLineGeom(lineId);
+
+  if (line.size() < 2) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  double bestDistance =
+      std::numeric_limits<double>::infinity();
+
+  for (size_t i = 1; i < line.size(); ++i) {
+    const double currentDistance = util::geo::distToSegment(
+              line[i - 1],line[i], queryPoint);
+
+    if (currentDistance < bestDistance) {
+      bestDistance = currentDistance;
+    }
+
+    if (bestDistance < 0.0001) {
+      break;
+    }
+  }
+  return bestDistance;
+}
+
+// _____________________________________________________________________________
+double Requestor::getPolygonDistance(
+    size_t polygonId,
+    const util::geo::DPoint& queryPoint,
+    double radius) const {
+  const auto border = extractLineGeom(polygonId);
+
+  if (border.size() < 3) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  const util::geo::DPolygon polygon(border);
+
+  if (util::geo::contains(queryPoint, polygon)) {
+    return radius / 4;
+  }
+
+  double bestDistance = std::numeric_limits<double>::infinity();
+
+  for (size_t i = 1; i < border.size(); ++i) {
+    const double currentDistance = util::geo::distToSegment(
+      border[i - 1], border[i], queryPoint);
+
+    if (currentDistance < bestDistance) {
+      bestDistance = currentDistance;
+    }
+
+    if (bestDistance < 0.0001) {
+      break;
+    }
+  }
+
+  return bestDistance;
+}
+
+// _____________________________________________________________________________
+util::geo::MultiLine<double> Requestor::geomLineGeoms(size_t lid,
+                                                      size_t oid,
                                                       double eps) const {
   const size_t gid = _lidToObject[lid];
   std::vector<util::geo::DLine> polys;

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -43,8 +43,8 @@ void Requestor::request(const std::string& remoteAddr) {
   _clusterObjects.clear();
 
   RequestReader reader(_cache->getConfig().backend, _maxMemory,
-                       _geomColumns.size(), _valueFlds.size(),
-                       _rasterMetaFlds.size());
+                       _geomColumns.size(), _valueColumns.size(),
+                       _rasterMetaColumns.size());
 
   _sortColumn = "";
 
@@ -66,73 +66,77 @@ void Requestor::request(const std::string& remoteAddr) {
     LOG(INFO) << "[REQUESTOR] Prepped query: " << prepedGeomQuery;
 
     reader.requestIds(prepedGeomQuery, remoteAddr);
-
-    size_t totNumIds = 0;
-    for (size_t i = 0; i < _geomColumns.size(); i++)
-      totNumIds += reader._ids[i].size();
   }
 
   // join with geoms from GeomCache
 
   // sort by qlever id
-  for (size_t i = 0; i < _geomColumns.size(); i++) {
-    LOG(INFO) << "[REQUESTOR] Sorting " << reader._ids[i].size()
-              << " results for column " << _geomColumns[i]
+  for (size_t gid = 0; gid < _geomColumns.size(); gid++) {
+    LOG(INFO) << "[REQUESTOR] Sorting " << reader._ids[gid].size()
+              << " results for column " << _geomColumns[gid]
               << " by qlever ID...";
-    std::sort(reader._ids[i].begin(), reader._ids[i].end());
+    std::sort(reader._ids[gid].begin(), reader._ids[gid].end());
   }
   LOG(INFO) << "[REQUESTOR] ... done";
 
   _objects.resize(_geomColumns.size());
-  _vals.resize(_geomColumns.size());
-  _valsMax.resize(_geomColumns.size(), 0);
-  _valsMin.resize(_geomColumns.size(), 1);
-  _rasterMetas.resize(_geomColumns.size());
   _dynamicPoints.resize(_geomColumns.size());
-  _pgrid.resize(_geomColumns.size());
-  _lgrid.resize(_geomColumns.size());
-  _agrid.resize(_geomColumns.size());
-  _lpgrid.resize(_geomColumns.size());
-  _numObjects.resize(_geomColumns.size());
   _clusterObjects.resize(_geomColumns.size());
+  _numObjects.resize(_geomColumns.size());
 
-  for (size_t geomColId = 0; geomColId < _geomColumns.size(); geomColId++) {
-    std::string fieldName = _geomColumns[geomColId];
+  _vals.resize(_valueColumns.size());
+  _valsMax.resize(_valueColumns.size(), 0);
+  _valsMin.resize(_valueColumns.size(), 1);
+
+  _rasterMetas.resize(_rasterMetaColumns.size());
+
+  _pgrid.resize(_gridSets.size());
+  _lgrid.resize(_gridSets.size());
+  _agrid.resize(_gridSets.size());
+  _lpgrid.resize(_gridSets.size());
+
+  // move the values, and calculate their range
+  for (size_t vid = 0; vid < _valueColumns.size(); vid++) {
+    _vals[vid] = std::move(reader._vals[vid]);
+
+    _valsMin[vid] = std::numeric_limits<double>::max();
+    _valsMax[vid] = std::numeric_limits<double>::lowest();
+
+    for (auto v : _vals[vid]) {
+      if (v < _valsMin[vid]) _valsMin[vid] = v;
+      if (v > _valsMax[vid]) _valsMax[vid] = v;
+    }
+  }
+
+  // move the raster metas
+  for (size_t rid = 0; rid < _rasterMetaColumns.size(); rid++) {
+    _rasterMetas[rid] = std::move(reader._rasterMetas[rid]);
+  }
+
+  // bounding boxes of the geometries, per distinct geo column
+  std::vector<util::geo::FBox> pointBboxes(_geomColumns.size());
+  std::vector<util::geo::FBox> lineBboxes(_geomColumns.size());
+
+  for (size_t gid = 0; gid < _geomColumns.size(); gid++) {
+    const std::string& fieldName = _geomColumns[gid];
     LOG(INFO) << "[REQUESTOR] Retrieving geoms from cache for field "
               << fieldName << "...";
     // (geom id, result row)
-    const auto& ret = _cache->getRelObjects(reader._ids[geomColId]);
-    _objects[geomColId] = ret.first;
-    _numObjects[geomColId] = ret.second;
+    const auto& ret = _cache->getRelObjects(reader._ids[gid]);
+    _objects[gid] = ret.first;
+    _numObjects[gid] = ret.second;
 
-    if (_valueFlds.count(geomColId)) {
-      _vals[geomColId] = std::move(reader._vals[_valueFlds[geomColId]]);
-
-      _valsMin[geomColId] = std::numeric_limits<double>::max();
-      _valsMax[geomColId] = std::numeric_limits<double>::lowest();
-
-      for (auto v : _vals[geomColId]) {
-        if (v < _valsMin[geomColId]) _valsMin[geomColId] = v;
-        if (v > _valsMax[geomColId]) _valsMax[geomColId] = v;
-      }
-    }
-
-    if (_rasterMetaFlds.count(geomColId)) {
-      _rasterMetas[geomColId] =
-          std::move(reader._rasterMetas[_rasterMetaFlds[geomColId]]);
-    }
-
-    LOG(INFO) << "[REQUESTOR] ... done, got " << _objects[geomColId].size()
+    LOG(INFO) << "[REQUESTOR] ... done, got " << _objects[gid].size()
               << " objects.";
 
     LOG(INFO) << "[REQUESTOR] Retrieving points dynamically from query...";
 
     // dynamic points present in query
-    _dynamicPoints[geomColId] = getDynamicPoints(reader._ids[geomColId]);
-    _numObjects[geomColId] += _dynamicPoints[geomColId].size();
+    _dynamicPoints[gid] = getDynamicPoints(reader._ids[gid]);
+    _numObjects[gid] += _dynamicPoints[gid].size();
 
-    LOG(INFO) << "[REQUESTOR] ... done, got "
-              << _dynamicPoints[geomColId].size() << " points.";
+    LOG(INFO) << "[REQUESTOR] ... done, got " << _dynamicPoints[gid].size()
+              << " points.";
 
     LOG(INFO) << "[REQUESTOR] Calculating bounding box of result...";
 
@@ -144,13 +148,13 @@ void Requestor::request(const std::string& remoteAddr) {
     util::geo::FBox pointBbox;
     util::geo::DBox lineBbox;
     size_t batch =
-        ceil(static_cast<double>(_objects[geomColId].size()) / NUM_THREADS);
+        ceil(static_cast<double>(_objects[gid].size()) / NUM_THREADS);
 
 #pragma omp parallel for num_threads(NUM_THREADS) schedule(static)
     for (size_t t = 0; t < NUM_THREADS; t++) {
       for (size_t i = batch * t;
-           i < batch * (t + 1) && i < _objects[geomColId].size(); i++) {
-        auto geomId = _objects[geomColId][i].first;
+           i < batch * (t + 1) && i < _objects[gid].size(); i++) {
+        auto geomId = _objects[gid][i].first;
 
         if (geomId < I_OFFSET) {
           auto pId = geomId;
@@ -166,14 +170,13 @@ void Requestor::request(const std::string& remoteAddr) {
       }
     }
 
-    batch = ceil(static_cast<double>(_dynamicPoints[geomColId].size()) /
-                 NUM_THREADS);
+    batch = ceil(static_cast<double>(_dynamicPoints[gid].size()) / NUM_THREADS);
 
 #pragma omp parallel for num_threads(NUM_THREADS) schedule(static)
     for (size_t t = 0; t < NUM_THREADS; t++) {
       for (size_t i = batch * t;
-           i < batch * (t + 1) && i < _dynamicPoints[geomColId].size(); i++) {
-        auto geom = _dynamicPoints[geomColId][i].first;
+           i < batch * (t + 1) && i < _dynamicPoints[gid].size(); i++) {
+        auto geom = _dynamicPoints[gid][i].first;
 
         pointBoxes[t] = util::geo::extendBox(geom, pointBoxes[t]);
       }
@@ -203,7 +206,30 @@ void Requestor::request(const std::string& remoteAddr) {
     } else {
       LOG(INFO) << "[REQUESTOR] Line BBox: " << util::geo::getWKT(lineBbox);
     }
-    LOG(INFO) << "[REQUESTOR] Building grid...";
+
+    pointBboxes[gid] = pointBbox;
+    lineBboxes[gid] = util::geo::FBox{
+        {lineBbox.getLowerLeft().getX(), lineBbox.getLowerLeft().getY()},
+        {lineBbox.getUpperRight().getX(), lineBbox.getUpperRight().getY()}};
+  }
+
+  // the clusters only depend on the geometries, they are built togethr with
+  // the first grid set of a geom column, no need to do that multiple times
+  std::vector<bool> clustersDone(_geomColumns.size(), false);
+
+  for (size_t gsid = 0; gsid < _gridSets.size(); gsid++) {
+    const size_t gid = _gridSets[gsid].first;
+    const size_t vid = _gridSets[gsid].second;
+
+    const bool buildClusters = !clustersDone[gid];
+    clustersDone[gid] = true;
+
+    LOG(INFO) << "[REQUESTOR] Building grid for geom column "
+              << _geomColumns[gid] << " weighted by "
+              << (vid == NO_COL ? "-" : _valueColumns[vid]) << "...";
+
+    const util::geo::FBox& pointBbox = pointBboxes[gid];
+    const util::geo::FBox& fLineBbox = lineBboxes[gid];
 
     double GRID_SIZE = 65536;
 
@@ -217,9 +243,9 @@ void Requestor::request(const std::string& remoteAddr) {
     double pyHeight = fmax(0, ceil(ph / GRID_SIZE));
 
     double lw =
-        lineBbox.getUpperRight().getX() - lineBbox.getLowerLeft().getX();
+        fLineBbox.getUpperRight().getX() - fLineBbox.getLowerLeft().getX();
     double lh =
-        lineBbox.getUpperRight().getY() - lineBbox.getLowerLeft().getY();
+        fLineBbox.getUpperRight().getY() - fLineBbox.getLowerLeft().getY();
 
     // estimate memory consumption of empty grid
     double lxWidth = fmax(0, ceil(lw / GRID_SIZE));
@@ -235,19 +261,14 @@ void Requestor::request(const std::string& remoteAddr) {
     checkMem(8 * (lxWidth * lyHeight), _maxMemory);
     // checkMem(8 * (lxWidth * lyHeight), _maxMemory);
 
-    util::geo::FBox fLineBbox = {
-        {lineBbox.getLowerLeft().getX(), lineBbox.getLowerLeft().getY()},
-        {lineBbox.getUpperRight().getX(), lineBbox.getUpperRight().getY()}};
-
-    _pgrid[geomColId] =
+    _pgrid[gsid] =
         petrimaps::Grid<ID_TYPE, float, float>(GRID_SIZE, GRID_SIZE, pointBbox);
-    _lgrid[geomColId] =
+    _lgrid[gsid] =
         petrimaps::Grid<ID_TYPE, float, float>(GRID_SIZE, GRID_SIZE, fLineBbox);
-    _agrid[geomColId] =
+    _agrid[gsid] =
         petrimaps::Grid<ID_TYPE, float, float>(GRID_SIZE, GRID_SIZE, fLineBbox);
-    _lpgrid[geomColId] =
-        petrimaps::Grid<util::geo::Point<uint8_t>, float, float>(
-            GRID_SIZE, GRID_SIZE, fLineBbox);
+    _lpgrid[gsid] = petrimaps::Grid<util::geo::Point<uint8_t>, float, float>(
+        GRID_SIZE, GRID_SIZE, fLineBbox);
 
     std::exception_ptr ePtr1, ePtr2, ePtr3, ePtr4;
 
@@ -255,33 +276,33 @@ void Requestor::request(const std::string& remoteAddr) {
     {
 #pragma omp section
       {
-        size_t j =
-            _objects[geomColId].size() + _dynamicPoints[geomColId].size();
+        size_t j = _objects[gid].size() + _dynamicPoints[gid].size();
 
-        for (size_t oid = 0; oid < _objects[geomColId].size(); oid++) {
-          const auto& p = _objects[geomColId][oid];
+        for (size_t oid = 0; oid < _objects[gid].size(); oid++) {
+          const auto& p = _objects[gid][oid];
           auto geomId = p.first;
           if (geomId >= I_OFFSET) continue;
 
           size_t clusterI = 0;
           // cluster if they have same geometry, don't do for multigeoms
-          while (oid < _objects[geomColId].size() - 1 &&
-                 geomId == _objects[geomColId][oid + 1].first) {
+          while (oid < _objects[gid].size() - 1 &&
+                 geomId == _objects[gid][oid + 1].first) {
             clusterI++;
             oid++;
           }
 
           if (clusterI > 0) {
             for (size_t m = 0; m < clusterI; m++) {
-              const auto& p = _objects[geomColId][oid - m];
-              _pgrid[geomColId].add(_cache->getPoints()[p.first],
-                                    getVal(geomColId, oid - m), j);
-              _clusterObjects[geomColId].push_back({oid - m, {m, clusterI}});
+              const auto& p = _objects[gid][oid - m];
+              _pgrid[gsid].add(_cache->getPoints()[p.first],
+                               getValFor(gid, vid, oid - m), j);
+              if (buildClusters)
+                _clusterObjects[gid].push_back({oid - m, {m, clusterI}});
               j++;
             }
           } else {
-            _pgrid[geomColId].add(_cache->getPoints()[geomId],
-                                  getVal(geomColId, oid), oid);
+            _pgrid[gsid].add(_cache->getPoints()[geomId],
+                             getValFor(gid, vid, oid), oid);
           }
 
           // every 100000 objects, check memory...
@@ -295,31 +316,33 @@ void Requestor::request(const std::string& remoteAddr) {
           }
         }
 
-        for (size_t i = 0; i < _dynamicPoints[geomColId].size(); i++) {
-          const auto& p = _dynamicPoints[geomColId][i];
+        for (size_t i = 0; i < _dynamicPoints[gid].size(); i++) {
+          const auto& p = _dynamicPoints[gid][i];
           auto geom = p.first;
 
           size_t clusterI = 0;
           // cluster if they have same geometry, don't do for multigeoms
-          while (i < _dynamicPoints[geomColId].size() - 1 &&
-                 geom == _dynamicPoints[geomColId][i + 1].first) {
+          while (i < _dynamicPoints[gid].size() - 1 &&
+                 geom == _dynamicPoints[gid][i + 1].first) {
             clusterI++;
             i++;
           }
 
           if (clusterI > 0) {
             for (size_t m = 0; m < clusterI; m++) {
-              const auto& p = _dynamicPoints[geomColId][i - m];
+              const auto& p = _dynamicPoints[gid][i - m];
               auto geom = p.first;
-              _pgrid[geomColId].add(geom, getVal(geomColId, j), j);
-              _clusterObjects[geomColId].push_back(
-                  {i - m + _objects[geomColId].size(), {m, clusterI}});
+              _pgrid[gsid].add(
+                  geom, getValFor(gid, vid, i - m + _objects[gid].size()), j);
+              if (buildClusters)
+                _clusterObjects[gid].push_back(
+                    {i - m + _objects[gid].size(), {m, clusterI}});
               j++;
             }
           } else {
-            _pgrid[geomColId].add(
-                geom, getVal(geomColId, i + _objects[geomColId].size()),
-                i + _objects[geomColId].size());
+            _pgrid[gsid].add(geom,
+                             getValFor(gid, vid, i + _objects[gid].size()),
+                             i + _objects[gid].size());
           }
 
           // every 100000 objects, check memory...
@@ -337,7 +360,7 @@ void Requestor::request(const std::string& remoteAddr) {
 #pragma omp section
       {
         size_t i = 0;
-        for (const auto& l : _objects[geomColId]) {
+        for (const auto& l : _objects[gid]) {
           if (l.first >= I_OFFSET &&
               l.first < std::numeric_limits<ID_TYPE>::max()) {
             auto geomId = l.first - I_OFFSET;
@@ -345,7 +368,7 @@ void Requestor::request(const std::string& remoteAddr) {
             util::geo::FBox fbox = {
                 {box.getLowerLeft().getX(), box.getLowerLeft().getY()},
                 {box.getUpperRight().getX(), box.getUpperRight().getY()}};
-            _lgrid[geomColId].add(fbox, getVal(geomColId, i), i);
+            _lgrid[gsid].add(fbox, getValFor(gid, vid, i), i);
           }
           i++;
 
@@ -364,7 +387,7 @@ void Requestor::request(const std::string& remoteAddr) {
 #pragma omp section
       {
         size_t i = 0;
-        for (const auto& l : _objects[geomColId]) {
+        for (const auto& l : _objects[gid]) {
           if (l.first >= I_OFFSET &&
               l.first < std::numeric_limits<ID_TYPE>::max()) {
             auto geomId = l.first - I_OFFSET;
@@ -381,7 +404,7 @@ void Requestor::request(const std::string& remoteAddr) {
             int lastX = 0;
             int lastY = 0;
 
-            double val = getVal(geomColId, i);
+            double val = getValFor(gid, vid, i);
 
             double area = 0;
             util::geo::FBox fbox;
@@ -412,32 +435,32 @@ void Requestor::request(const std::string& remoteAddr) {
 
               lastP = curP;
 
-              size_t cellX = _lpgrid[geomColId].getCellXFromX(curP.getX());
-              size_t cellY = _lpgrid[geomColId].getCellYFromY(curP.getY());
+              size_t cellX = _lpgrid[gsid].getCellXFromX(curP.getX());
+              size_t cellY = _lpgrid[gsid].getCellYFromY(curP.getY());
 
-              uint8_t sX = (curP.getX() -
-                            _lpgrid[geomColId].getBBox().getLowerLeft().getX() +
-                            cellX * _lpgrid[geomColId].getCellWidth()) /
-                           256;
-              uint8_t sY = (curP.getY() -
-                            _lpgrid[geomColId].getBBox().getLowerLeft().getY() +
-                            cellY * _lpgrid[geomColId].getCellHeight()) /
-                           256;
+              uint8_t sX =
+                  (curP.getX() - _lpgrid[gsid].getBBox().getLowerLeft().getX() +
+                   cellX * _lpgrid[gsid].getCellWidth()) /
+                  256;
+              uint8_t sY =
+                  (curP.getY() - _lpgrid[gsid].getBBox().getLowerLeft().getY() +
+                   cellY * _lpgrid[gsid].getCellHeight()) /
+                  256;
 
-              const auto& cellBox = _lpgrid[geomColId].getBox(cellX, cellY);
+              const auto& cellBox = _lpgrid[gsid].getBox(cellX, cellY);
 
               int fullX = cellBox.getLowerLeft().getX() + sX * 256;
               int fullY = cellBox.getLowerLeft().getY() + sY * 256;
 
               if (gi == 3 || lastX != fullX || lastY != fullY) {
-                _lpgrid[geomColId].add(cellX, cellY, val, {sX, sY});
+                _lpgrid[gsid].add(cellX, cellY, val, {sX, sY});
                 lastX = fullX;
                 lastY = fullY;
               }
             }
 
             if (lineIsArea && fabs(area) > (2000.0 * 2000.0)) {
-              _agrid[geomColId].add(fbox, val, i);
+              _agrid[gsid].add(fbox, val, i);
             }
           }
           i++;
@@ -530,15 +553,12 @@ std::vector<std::string> Requestor::getColumns(const std::string& backend,
 std::string Requestor::prepQuery(std::string query,
                                  std::vector<std::string> columns,
                                  std::string sortBy) const {
-  std::vector<std::string> rawCols;
-  for (const auto& col : columns) rawCols.push_back(util::split(col, ':')[0]);
-
   std::regex expr("select[^{]*(\\*|[\\?$][A-Z0-9_\\-+]*)+[^{]*\\s*\\{",
                   std::regex_constants::icase);
 
   query =
       std::regex_replace(query, expr,
-                         "SELECT " + util::implode(rawCols, " ") + " WHERE {$&",
+                         "SELECT " + util::implode(columns, " ") + " WHERE {$&",
                          std::regex_constants::format_first_only) +
       "}";
 
@@ -566,7 +586,7 @@ std::string Requestor::prepQueryRow(std::string query, uint64_t row) const {
 const ResObj Requestor::getNearest(util::geo::DPoint rp, double rad, double res,
                                    util::geo::FBox fullbox,
                                    const std::string& remoteAddr) const {
-  for (size_t lid = 0; lid < getNumFields(); lid++) {
+  for (size_t lid = 0; lid < getNumLayers(); lid++) {
     auto r = getNearest(lid, rp, rad, res, fullbox, remoteAddr);
     if (r.has) return r;
   }
@@ -575,13 +595,16 @@ const ResObj Requestor::getNearest(util::geo::DPoint rp, double rad, double res,
 }
 
 // _____________________________________________________________________________
-const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
-                                   double rad, double res,
-                                   util::geo::FBox fullbox,
+const ResObj Requestor::getNearest(size_t lid, util::geo::DPoint rp, double rad,
+                                   double res, util::geo::FBox fullbox,
                                    const std::string& remoteAddr) const {
   if (!_cache->ready()) {
     throw std::runtime_error("Geom cache not ready");
   }
+
+  const size_t gid = _lidToObject[lid];
+  const size_t gsid = _lidToGrid[lid];
+
   auto box = pad(getBoundingBox(rp), rad);
   auto fbox = pad(getBoundingBox(util::geo::FPoint(rp.getX(), rp.getY())), rad);
 
@@ -608,19 +631,19 @@ const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
       std::vector<ID_TYPE> ret;
 
       if (res > 0)
-        _pgrid[fieldId].get(fullbox, &ret);
+        _pgrid[gsid].get(fullbox, &ret);
       else
-        _pgrid[fieldId].get(fbox, &ret);
+        _pgrid[gsid].get(fbox, &ret);
 
 #pragma omp parallel for num_threads(NUM_THREADS) schedule(static)
       for (size_t idx = 0; idx < ret.size(); idx++) {
         auto oid = ret[idx];
         util::geo::FPoint p;
-        if (isCluster(fieldId, oid)) {
-          auto dp = clusterGeom(fieldId, oid, res);
+        if (isCluster(lid, oid)) {
+          auto dp = clusterGeom(lid, oid, res);
           p = {dp.getX(), dp.getY()};
         } else {
-          p = getPoint(fieldId, oid);
+          p = getPoint(lid, oid);
         }
 
         if (!util::geo::contains(p, fbox)) continue;
@@ -638,18 +661,16 @@ const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
     {
       // lines
       std::vector<ID_TYPE> retL;
-      _lgrid[fieldId].get(fbox, &retL);
+      _lgrid[gsid].get(fbox, &retL);
 
 #pragma omp parallel for num_threads(NUM_THREADS) schedule(static)
       for (size_t idx = 0; idx < retL.size(); idx++) {
         const auto& oid = retL[idx];
-        auto lBox =
-            _cache->getLineBBox(_objects[fieldId][oid].first - I_OFFSET);
+        auto lBox = _cache->getLineBBox(_objects[gid][oid].first - I_OFFSET);
         if (!util::geo::intersects(lBox, box)) continue;
 
-        size_t start = _cache->getLine(_objects[fieldId][oid].first - I_OFFSET);
-        size_t end =
-            _cache->getLineEnd(_objects[fieldId][oid].first - I_OFFSET);
+        size_t start = _cache->getLine(_objects[gid][oid].first - I_OFFSET);
+        size_t end = _cache->getLineEnd(_objects[gid][oid].first - I_OFFSET);
 
         // TODO _____________________ own function
         double d = std::numeric_limits<double>::infinity();
@@ -662,8 +683,7 @@ const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
         double mainX = 0;
         double mainY = 0;
 
-        bool isArea =
-            Requestor::isArea(_objects[fieldId][oid].first - I_OFFSET);
+        bool isArea = Requestor::isArea(_objects[gid][oid].first - I_OFFSET);
 
         util::geo::DLine areaBorder;
 
@@ -739,44 +759,44 @@ const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
   }
 
   if (dBest < rad && dBest <= dBestL) {
-    size_t row = getRow(fieldId, nearest);
-    auto points = geomPointGeoms(fieldId, nearest, res);
+    size_t row = getRow(lid, nearest);
+    auto points = geomPointGeoms(lid, nearest, res);
 
     return {true,
             nearest,
-            fieldId,
+            lid,
             points.size() == 1 ? points[0] : util::geo::centroid(points),
             requestRow(row, remoteAddr),
             points,
-            geomLineGeoms(fieldId, nearest, rad / 10),
-            geomPolyGeoms(fieldId, nearest, rad / 10)};
+            geomLineGeoms(lid, nearest, rad / 10),
+            geomPolyGeoms(lid, nearest, rad / 10)};
   }
 
   if (dBestL < rad && dBestL <= dBest) {
-    size_t lineId = _objects[fieldId][nearestL].first - I_OFFSET;
+    size_t lineId = _objects[gid][nearestL].first - I_OFFSET;
     const auto& dline = extractLineGeom(lineId);
 
     if (Requestor::isArea(lineId) &&
         util::geo::contains(rp, util::geo::DPolygon(dline))) {
       return {true,
               nearestL,
-              fieldId,
+              lid,
               {frp.getX(), frp.getY()},
-              requestRow(_objects[fieldId][nearestL].second, remoteAddr),
-              geomPointGeoms(fieldId, nearestL, res),
-              geomLineGeoms(fieldId, nearestL, rad / 10),
-              geomPolyGeoms(fieldId, nearestL, rad / 10)};
+              requestRow(_objects[gid][nearestL].second, remoteAddr),
+              geomPointGeoms(lid, nearestL, res),
+              geomLineGeoms(lid, nearestL, rad / 10),
+              geomPolyGeoms(lid, nearestL, rad / 10)};
     } else {
       auto p = util::geo::PolyLine<double>(dline).projectOn(rp).p;
       auto fp = util::geo::DPoint(p.getX(), p.getY());
       return {true,
               nearestL,
-              fieldId,
+              lid,
               fp,
-              requestRow(_objects[fieldId][nearestL].second, remoteAddr),
-              geomPointGeoms(fieldId, nearestL, res),
-              geomLineGeoms(fieldId, nearestL, rad / 10),
-              geomPolyGeoms(fieldId, nearestL, rad / 10)};
+              requestRow(_objects[gid][nearestL].second, remoteAddr),
+              geomPointGeoms(lid, nearestL, res),
+              geomLineGeoms(lid, nearestL, rad / 10),
+              geomPolyGeoms(lid, nearestL, rad / 10)};
     }
   }
 
@@ -784,19 +804,19 @@ const ResObj Requestor::getNearest(size_t fieldId, util::geo::DPoint rp,
 }
 
 // _____________________________________________________________________________
-const ResObj Requestor::getGeom(size_t fieldId, size_t id, double rad) const {
+const ResObj Requestor::getGeom(size_t lid, size_t id, double rad) const {
   if (!_cache->ready()) {
     throw std::runtime_error("Geom cache not ready");
   }
 
   return {true,
           id,
-          fieldId,
+          lid,
           {0, 0},
           {},
-          geomPointGeoms(fieldId, id, rad / 10),
-          geomLineGeoms(fieldId, id, rad / 10),
-          geomPolyGeoms(fieldId, id, rad / 10)};
+          geomPointGeoms(lid, id, rad / 10),
+          geomLineGeoms(lid, id, rad / 10),
+          geomPolyGeoms(lid, id, rad / 10)};
 }
 
 // _____________________________________________________________________________
@@ -857,33 +877,31 @@ bool Requestor::isInnerArea(size_t lineId) const {
 }
 
 // _____________________________________________________________________________
-util::geo::MultiLine<double> Requestor::geomLineGeoms(size_t fieldId,
-                                                      size_t oid,
+util::geo::MultiLine<double> Requestor::geomLineGeoms(size_t lid, size_t oid,
                                                       double eps) const {
+  const size_t gid = _lidToObject[lid];
   std::vector<util::geo::DLine> polys;
 
   // catch multigeometries
-  for (size_t i = oid;
-       i < _objects[fieldId].size() &&
-       _objects[fieldId][i].second == _objects[fieldId][oid].second;
+  for (size_t i = oid; i < _objects[gid].size() &&
+                       _objects[gid][i].second == _objects[gid][oid].second;
        i++) {
-    if (_objects[fieldId][i].first < I_OFFSET ||
-        Requestor::isArea(_objects[fieldId][i].first - I_OFFSET))
+    if (_objects[gid][i].first < I_OFFSET ||
+        Requestor::isArea(_objects[gid][i].first - I_OFFSET))
       continue;
-    const auto& fline = extractLineGeom(_objects[fieldId][i].first - I_OFFSET);
+    const auto& fline = extractLineGeom(_objects[gid][i].first - I_OFFSET);
     polys.push_back(util::geo::simplify(fline, eps));
   }
 
   if (oid > 0) {
     for (size_t i = oid - 1;
-         i < _objects[fieldId].size() &&
-         _objects[fieldId][i].second == _objects[fieldId][oid].second;
+         i < _objects[gid].size() &&
+         _objects[gid][i].second == _objects[gid][oid].second;
          i--) {
-      if (_objects[fieldId][i].first < I_OFFSET ||
-          Requestor::isArea(_objects[fieldId][i].first - I_OFFSET))
+      if (_objects[gid][i].first < I_OFFSET ||
+          Requestor::isArea(_objects[gid][i].first - I_OFFSET))
         continue;
-      const auto& fline =
-          extractLineGeom(_objects[fieldId][i].first - I_OFFSET);
+      const auto& fline = extractLineGeom(_objects[gid][i].first - I_OFFSET);
       polys.push_back(util::geo::simplify(fline, eps));
     }
   }
@@ -892,49 +910,48 @@ util::geo::MultiLine<double> Requestor::geomLineGeoms(size_t fieldId,
 }
 
 // _____________________________________________________________________________
-util::geo::MultiPoint<double> Requestor::geomPointGeoms(size_t fieldId,
+util::geo::MultiPoint<double> Requestor::geomPointGeoms(size_t lid,
                                                         size_t oid) const {
-  return geomPointGeoms(fieldId, oid, -1);
+  return geomPointGeoms(lid, oid, -1);
 }
 
 // _____________________________________________________________________________
-util::geo::MultiPoint<double> Requestor::geomPointGeoms(size_t fieldId,
-                                                        size_t oid,
+util::geo::MultiPoint<double> Requestor::geomPointGeoms(size_t lid, size_t oid,
                                                         double res) const {
+  const size_t gid = _lidToObject[lid];
   std::vector<util::geo::DPoint> points;
 
-  if (!(res < 0) && isCluster(fieldId, oid)) {
-    return {clusterGeom(fieldId, oid, res)};
+  if (!(res < 0) && isCluster(lid, oid)) {
+    return {clusterGeom(lid, oid, res)};
   }
 
-  if (isCluster(fieldId, oid)) {
-    oid = getCluster(fieldId, oid).first;
+  if (isCluster(lid, oid)) {
+    oid = getCluster(lid, oid).first;
   }
 
-  if (oid >= _objects[fieldId].size()) {
+  if (oid >= _objects[gid].size()) {
     points.push_back(
-        {_dynamicPoints[fieldId][oid - _objects[fieldId].size()].first.getX(),
-         _dynamicPoints[fieldId][oid - _objects[fieldId].size()].first.getY()});
+        {_dynamicPoints[gid][oid - _objects[gid].size()].first.getX(),
+         _dynamicPoints[gid][oid - _objects[gid].size()].first.getY()});
     return points;
   }
 
   // catch multigeometries, not relevant for dynamic points
-  for (size_t i = oid;
-       i < _objects[fieldId].size() &&
-       _objects[fieldId][i].second == _objects[fieldId][oid].second;
+  for (size_t i = oid; i < _objects[gid].size() &&
+                       _objects[gid][i].second == _objects[gid][oid].second;
        i++) {
-    if (_objects[fieldId][i].first >= I_OFFSET) continue;
-    auto p = _cache->getPoints()[_objects[fieldId][i].first];
+    if (_objects[gid][i].first >= I_OFFSET) continue;
+    auto p = _cache->getPoints()[_objects[gid][i].first];
     points.push_back({p.getX(), p.getY()});
   }
 
   if (oid > 0) {
     for (size_t i = oid - 1;
-         i < _objects[fieldId].size() &&
-         _objects[fieldId][i].second == _objects[fieldId][oid].second;
+         i < _objects[gid].size() &&
+         _objects[gid][i].second == _objects[gid][oid].second;
          i--) {
-      if (_objects[fieldId][i].first >= I_OFFSET) continue;
-      auto p = _cache->getPoints()[_objects[fieldId][i].first];
+      if (_objects[gid][i].first >= I_OFFSET) continue;
+      auto p = _cache->getPoints()[_objects[gid][i].first];
       points.push_back({p.getX(), p.getY()});
     }
   }
@@ -943,33 +960,31 @@ util::geo::MultiPoint<double> Requestor::geomPointGeoms(size_t fieldId,
 }
 
 // _____________________________________________________________________________
-util::geo::MultiPolygon<double> Requestor::geomPolyGeoms(size_t fieldId,
-                                                         size_t oid,
+util::geo::MultiPolygon<double> Requestor::geomPolyGeoms(size_t lid, size_t oid,
                                                          double eps) const {
+  const size_t gid = _lidToObject[lid];
   std::vector<util::geo::DPolygon> polys;
 
   // catch multigeometries
-  for (size_t i = oid;
-       i < _objects[fieldId].size() &&
-       _objects[fieldId][i].second == _objects[fieldId][oid].second;
+  for (size_t i = oid; i < _objects[gid].size() &&
+                       _objects[gid][i].second == _objects[gid][oid].second;
        i++) {
-    if (_objects[fieldId][i].first < I_OFFSET ||
-        !Requestor::isArea(_objects[fieldId][i].first - I_OFFSET))
+    if (_objects[gid][i].first < I_OFFSET ||
+        !Requestor::isArea(_objects[gid][i].first - I_OFFSET))
       continue;
-    const auto& dline = extractLineGeom(_objects[fieldId][i].first - I_OFFSET);
+    const auto& dline = extractLineGeom(_objects[gid][i].first - I_OFFSET);
     polys.push_back(util::geo::DPolygon(util::geo::simplify(dline, eps)));
   }
 
   if (oid > 0) {
     for (size_t i = oid - 1;
-         i < _objects[fieldId].size() &&
-         _objects[fieldId][i].second == _objects[fieldId][oid].second;
+         i < _objects[gid].size() &&
+         _objects[gid][i].second == _objects[gid][oid].second;
          i--) {
-      if (_objects[fieldId][i].first < I_OFFSET ||
-          !Requestor::isArea(_objects[fieldId][i].first - I_OFFSET))
+      if (_objects[gid][i].first < I_OFFSET ||
+          !Requestor::isArea(_objects[gid][i].first - I_OFFSET))
         continue;
-      const auto& dline =
-          extractLineGeom(_objects[fieldId][i].first - I_OFFSET);
+      const auto& dline = extractLineGeom(_objects[gid][i].first - I_OFFSET);
       polys.push_back(util::geo::DPolygon(util::geo::simplify(dline, eps)));
     }
   }
@@ -1014,18 +1029,18 @@ std::vector<std::pair<util::geo::FPoint, ID_TYPE>> Requestor::getDynamicPoints(
 }
 
 // _____________________________________________________________________________
-util::geo::DPoint Requestor::clusterGeom(size_t fieldId, size_t oid,
+util::geo::DPoint Requestor::clusterGeom(size_t lid, size_t oid,
                                          double res) const {
-  size_t cid =
-      oid - getObjects(fieldId).size() - getDynamicPoints(fieldId).size();
-  size_t refOid = _clusterObjects[fieldId][cid].first;
+  const size_t gid = _lidToObject[lid];
+  size_t cid = oid - getObjects(lid).size() - getDynamicPoints(lid).size();
+  size_t refOid = _clusterObjects[gid][cid].first;
 
-  util::geo::FPoint pp = getPoint(fieldId, refOid);
+  util::geo::FPoint pp = getPoint(lid, refOid);
 
   if (res < 0) return {pp.getX(), pp.getY()};
 
-  size_t num = _clusterObjects[fieldId][cid].second.first;
-  size_t tot = _clusterObjects[fieldId][cid].second.second;
+  size_t num = _clusterObjects[gid][cid].second.first;
+  size_t tot = _clusterObjects[gid][cid].second.second;
 
   double a = 25;
   double b = 6;
@@ -1111,51 +1126,58 @@ bool Requestor::lineIntersects(size_t lineId,
 }
 
 // _____________________________________________________________________________
-std::pair<double, double> Requestor::getValRange(size_t fid) const {
-  if (_valsMin[fid] >= _valsMax[fid]) return {0, 0};
-  return {_valsMin[fid], _valsMax[fid]};
+std::pair<double, double> Requestor::getValRange(size_t lid) const {
+  const size_t vid = _lidToValue[lid];
+  if (vid == NO_COL) return {0, 0};
+  if (_valsMin[vid] >= _valsMax[vid]) return {0, 0};
+  return {_valsMin[vid], _valsMax[vid]};
 }
 
 // _____________________________________________________________________________
 std::pair<double, double> Requestor::getRasterMetas(
-    size_t fieldId, size_t oid, std::pair<double, double> def) const {
-  if (oid < _objects[fieldId].size()) {
-    if (_objects[fieldId][oid].second >= _rasterMetas[fieldId].size())
-      return def;
-    size_t did = _rasterMetas[fieldId][_objects[fieldId][oid].second];
-    return _cache->getRasterMeta(did);
-  }
-  if (oid >= _objects[fieldId].size()) {
-    if (_dynamicPoints[fieldId][oid - _objects[fieldId].size()].second >=
-        _rasterMetas[fieldId].size())
-      return def;
-    size_t did =
-        _rasterMetas[fieldId]
-                    [_dynamicPoints[fieldId][oid - _objects[fieldId].size()]
-                         .second];
-    return _cache->getRasterMeta(did);
+    size_t lid, size_t oid, std::pair<double, double> def) const {
+  const size_t gid = _lidToObject[lid];
+  const size_t rid = _lidToRaster[lid];
+
+  if (rid == NO_COL) return def;
+
+  const auto& rasterMetas = _rasterMetas[rid];
+
+  if (oid < _objects[gid].size()) {
+    if (_objects[gid][oid].second >= rasterMetas.size()) return def;
+    return _cache->getRasterMeta(rasterMetas[_objects[gid][oid].second]);
   }
 
-  return def;
+  // dynamic points
+  const size_t did = oid - _objects[gid].size();
+  if (did >= _dynamicPoints[gid].size()) return def;
+  if (_dynamicPoints[gid][did].second >= rasterMetas.size()) return def;
+  return _cache->getRasterMeta(rasterMetas[_dynamicPoints[gid][did].second]);
 }
 
 // _____________________________________________________________________________
-double Requestor::getVal(size_t fieldId, size_t oid) const {
+double Requestor::getVal(size_t lid, size_t oid) const {
+  return getValFor(_lidToObject[lid], _lidToValue[lid], oid);
+}
+
+// _____________________________________________________________________________
+double Requestor::getValFor(size_t gid, size_t vid, size_t oid) const {
   // shortcut
-  if (_vals[fieldId].size() == 0) return 1;
+  if (vid == NO_COL) return 1;
 
-  if (oid < _objects[fieldId].size()) {
-    if (_objects[fieldId][oid].second >= _vals[fieldId].size()) return 1;
-    return _vals[fieldId][_objects[fieldId][oid].second];
-  }
-  if (oid >= _objects[fieldId].size()) {
-    if (_dynamicPoints[fieldId][oid - _objects[fieldId].size()].second >=
-        _vals[fieldId].size())
-      return 1;
-    return _vals[fieldId]
-                [_dynamicPoints[fieldId][oid - _objects[fieldId].size()]
-                     .second];
+  const auto& vals = _vals[vid];
+
+  // shortcut
+  if (vals.size() == 0) return 1;
+
+  if (oid < _objects[gid].size()) {
+    if (_objects[gid][oid].second >= vals.size()) return 1;
+    return vals[_objects[gid][oid].second];
   }
 
-  return 1;
+  // dynamic points
+  const size_t did = oid - _objects[gid].size();
+  if (did >= _dynamicPoints[gid].size()) return 1;
+  if (_dynamicPoints[gid][did].second >= vals.size()) return 1;
+  return vals[_dynamicPoints[gid][did].second];
 }

--- a/src/qlever-petrimaps/server/Requestor.h
+++ b/src/qlever-petrimaps/server/Requestor.h
@@ -40,6 +40,10 @@ struct LayerConfig {
   std::string colorscheme = "spectralexp";
   std::string style = "auto";
   ObjectStyle objectStyle;
+
+  const std::string geomFieldRaw() const {
+    return util::split(geomField, ':')[0];
+  }
 };
 
 struct RequestorConfig {
@@ -242,6 +246,15 @@ class Requestor {
   util::geo::DLine extractLineGeom(size_t lineId, double minD = 0) const;
   bool isArea(size_t lineId) const;
   bool isInnerArea(size_t lineId) const;
+
+  double getLineDistance(
+      size_t lineId,
+      const util::geo::DPoint& queryPoint) const;
+
+  double getPolygonDistance(
+      size_t polygonId,
+      const util::geo::DPoint& queryPoint,
+      double radius) const;
 
   // total number of objects over all distinct geometry columns
   size_t getNumObjects() const {

--- a/src/qlever-petrimaps/server/Requestor.h
+++ b/src/qlever-petrimaps/server/Requestor.h
@@ -25,6 +25,7 @@ struct FieldConfig {
   std::string geomField = "";
   std::string id = "";
   std::string name = "";
+  std::string group = "";
   std::string valueField = "";
   std::string rasterMetaField = "";
   std::string toggle = "";
@@ -48,7 +49,7 @@ struct RequestorConfig {
     std::string fieldsStr;
     for (const auto& field : fields)
       fieldsStr += field.geomField + "|" + field.valueField + "|" +
-                   std::to_string(field.rasterW) + "|" +
+                   field.group + "|" + std::to_string(field.rasterW) + "|" +
                    std::to_string(field.rasterH) + "|" + field.color + "|" +
                    field.id + "|" + field.name + "|" + field.style + "|" +
                    field.colorscheme + "|" + field.toggle;
@@ -78,25 +79,22 @@ class Requestor {
         _rcfg(rcfg),
         _maxMemory(maxMemory),
         _createdAt(std::chrono::system_clock::now()) {
-    auto columns = getColumns(_rcfg.query);
+    auto columns = getColumns(_cache->getConfig().backend, _rcfg.query);
     for (size_t i = 0; i < columns.size(); i++) _columnsMap[columns[i]] = i;
 
-    if (_rcfg.fields.size() == 0) {
-      _geomColumns = {columns.back()};
-      _rcfg.fields.push_back({columns.back()});
-    } else {
-      for (const auto& field : _rcfg.fields) {
-        if (!_columnsMap.count(field.geomFieldRaw())) continue;
-        _geomColumns.push_back(field.geomField);
-        if (_columnsMap.count(field.valueField)) {
-          _valueFlds[_geomColumns.size() - 1] = _valueColumns.size();
-          _valueColumns.push_back(field.valueField);
-        }
-        if (_columnsMap.count(field.rasterMetaField)) {
-          _rasterMetaFlds[_geomColumns.size() - 1] = _rasterMetaColumns.size();
-          _rasterMetaColumns.push_back(field.rasterMetaField);
-        }
+    for (const auto& field : _rcfg.fields) {
+      if (!_columnsMap.count(field.geomFieldRaw())) continue;
+      _geomColumns.push_back(field.geomField);
+      if (_columnsMap.count(field.valueField)) {
+        _valueFlds[_geomColumns.size() - 1] = _valueColumns.size();
+        _valueColumns.push_back(field.valueField);
       }
+      if (_columnsMap.count(field.rasterMetaField)) {
+        _rasterMetaFlds[_geomColumns.size() - 1] = _rasterMetaColumns.size();
+        _rasterMetaColumns.push_back(field.rasterMetaField);
+      }
+      _fields.push_back(field);
+      _layerIdToLid[field.id] = _fields.size() - 1;
     }
 
     LOG(util::LogLevel::INFO)
@@ -230,23 +228,27 @@ class Requestor {
   size_t getNumObjects(size_t lid) const { return _numObjects[lid]; }
   util::geo::DPoint clusterGeom(size_t fieldId, size_t oid, double res) const;
 
-  std::vector<std::string> getColumns(std::string query) const;
+  static std::vector<std::string> getColumns(const std::string& backend,
+                                             std::string query);
 
   double getVal(size_t lid, size_t oid) const;
   std::pair<double, double> getRasterMetas(size_t lid, size_t oid,
                                            std::pair<double, double> def) const;
 
-  size_t getFieldId(const std::string& field) {
-    auto it = _geoColToLid.find(field);
-    std::stringstream ss;
-    ss << "Field '" << field << "' not found";
-    if (it == _geoColToLid.end()) throw std::runtime_error(ss.str());
-    return it->second;
-  }
   size_t getNumFields() const { return _pgrid.size(); }
   bool lineIntersects(size_t lid, const util::geo::DBox& bbox) const;
 
-  const std::vector<FieldConfig> getFields() const { return _rcfg.fields; }
+  const std::vector<FieldConfig>& getFields() const { return _fields; }
+
+  size_t getFieldById(const std::string& id) {
+    auto it = _layerIdToLid.find(id);
+    if (it == _layerIdToLid.end()) {
+      std::stringstream ss;
+      ss << "Field '" << id << "' not found";
+      throw std::runtime_error(ss.str());
+    }
+    return it->second;
+  }
   std::pair<double, double> getValRange(size_t fid) const;
 
   std::chrono::time_point<std::chrono::system_clock> createdAt() const {
@@ -265,6 +267,7 @@ class Requestor {
 
   std::shared_ptr<const GeomCache> _cache;
   RequestorConfig _rcfg;
+  std::vector<FieldConfig> _fields;
 
   size_t _maxMemory;
 
@@ -295,6 +298,7 @@ class Requestor {
   std::vector<std::string> _rasterMetaColumns;
   std::map<std::string, size_t> _columnsMap;
   std::map<std::string, size_t> _geoColToLid;
+  std::map<std::string, size_t> _layerIdToLid;
   std::map<size_t, size_t> _valueFlds;
   std::map<size_t, size_t> _rasterMetaFlds;
 

--- a/src/qlever-petrimaps/server/Requestor.h
+++ b/src/qlever-petrimaps/server/Requestor.h
@@ -7,10 +7,12 @@
 
 #include <chrono>
 #include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "qlever-petrimaps/GeomCache.h"
@@ -21,7 +23,9 @@
 
 namespace petrimaps {
 
-struct FieldConfig {
+static const size_t NO_COL = std::numeric_limits<size_t>::max();
+
+struct LayerConfig {
   std::string geomField = "";
   std::string id = "";
   std::string name = "";
@@ -34,26 +38,22 @@ struct FieldConfig {
   std::string color = "3388ff";
   std::string colorscheme = "spectralexp";
   std::string style = "auto";
-
-  const std::string geomFieldRaw() const {
-    return util::split(geomField, ':')[0];
-  }
 };
 
 struct RequestorConfig {
   std::string query;
-  std::vector<FieldConfig> fields;
+  std::vector<LayerConfig> layers;
 
   std::string getHash() const {
     std::hash<std::string> hashF;
-    std::string fieldsStr;
-    for (const auto& field : fields)
-      fieldsStr += field.geomField + "|" + field.valueField + "|" +
-                   field.group + "|" + std::to_string(field.rasterW) + "|" +
-                   std::to_string(field.rasterH) + "|" + field.color + "|" +
-                   field.id + "|" + field.name + "|" + field.style + "|" +
-                   field.colorscheme + "|" + field.toggle;
-    return std::to_string(hashF(query + fieldsStr));
+    std::string layersStr;
+    for (const auto& layer : layers)
+      layersStr += layer.geomField + "|" + layer.valueField + "|" +
+                   layer.group + "|" + std::to_string(layer.rasterW) + "|" +
+                   std::to_string(layer.rasterH) + "|" + layer.color + "|" +
+                   layer.id + "|" + layer.name + "|" + layer.style + "|" +
+                   layer.colorscheme + "|" + layer.toggle;
+    return std::to_string(hashF(query + layersStr));
   }
 };
 
@@ -82,27 +82,51 @@ class Requestor {
     auto columns = getColumns(_cache->getConfig().backend, _rcfg.query);
     for (size_t i = 0; i < columns.size(); i++) _columnsMap[columns[i]] = i;
 
-    for (const auto& field : _rcfg.fields) {
-      if (!_columnsMap.count(field.geomFieldRaw())) continue;
-      _geomColumns.push_back(field.geomField);
-      if (_columnsMap.count(field.valueField)) {
-        _valueFlds[_geomColumns.size() - 1] = _valueColumns.size();
-        _valueColumns.push_back(field.valueField);
+    // try to make geom cols, value cols and raster cols unique
+    std::map<std::string, size_t> geomColToGid, valueColToVid, rasterColToRid;
+
+    // grids can only be unique per combination of (gid, vid)
+    std::map<std::pair<size_t, size_t>, size_t> gridSetIdx;
+
+    // logic here: there a user-layers (in _rcfg.layers), but these may
+    // share geom columns, layer columns and raster columns. These are made
+    // unique, and an additional mapping layer lid -> gid, lid -> vid and lid
+    // ->rid is added
+    for (const auto& layer : _rcfg.layers) {
+      // if the field was not found at all in the column map, simply ignore it
+      if (!_columnsMap.count(layer.geomField)) continue;
+
+      size_t gid = uniqueCol(layer.geomField, &_geomColumns, &geomColToGid);
+      size_t vid =
+          _columnsMap.count(layer.valueField)
+              ? uniqueCol(layer.valueField, &_valueColumns, &valueColToVid)
+              : NO_COL;
+      size_t rid = _columnsMap.count(layer.rasterMetaField)
+                       ? uniqueCol(layer.rasterMetaField, &_rasterMetaColumns,
+                                   &rasterColToRid)
+                       : NO_COL;
+
+      std::pair<size_t, size_t> gridKey{gid, vid};
+      auto gridIt = gridSetIdx.find(gridKey);
+      if (gridIt == gridSetIdx.end()) {
+        _gridSets.push_back(gridKey);
+        gridIt = gridSetIdx.insert({gridKey, _gridSets.size() - 1}).first;
       }
-      if (_columnsMap.count(field.rasterMetaField)) {
-        _rasterMetaFlds[_geomColumns.size() - 1] = _rasterMetaColumns.size();
-        _rasterMetaColumns.push_back(field.rasterMetaField);
-      }
-      _fields.push_back(field);
-      _layerIdToLid[field.id] = _fields.size() - 1;
+
+      _layers.push_back(layer);
+      _layerIdToLid[layer.id] = _layers.size() - 1;
+
+      _lidToObject.push_back(gid);
+      _lidToValue.push_back(vid);
+      _lidToRaster.push_back(rid);
+      _lidToGrid.push_back(gridIt->second);
     }
 
     LOG(util::LogLevel::INFO)
-        << "[REQUESTOR] " << _geomColumns.size() << " geom columns";
-
-    for (size_t i = 0; i < _geomColumns.size(); i++) {
-      _geoColToLid[_geomColumns[i]] = i;
-    }
+        << "[REQUESTOR] " << _layers.size() << " layers, "
+        << _geomColumns.size() << " geom columns, " << _valueColumns.size()
+        << " value columns, " << _rasterMetaColumns.size()
+        << " raster columns, " << _gridSets.size() << " grid sets";
   }
 
   void request(const std::string& remoteAddr);
@@ -116,70 +140,68 @@ class Requestor {
           cb,
       const std::string& remoteAddr) const;
 
-  const petrimaps::Grid<ID_TYPE, float, float>& getPointGrid(
-      size_t fieldId) const {
-    return _pgrid[fieldId];
+  const petrimaps::Grid<ID_TYPE, float, float>& getPointGrid(size_t lid) const {
+    return _pgrid[_lidToGrid[lid]];
   }
 
-  const petrimaps::Grid<ID_TYPE, float, float>& getLineGrid(
-      size_t fieldId) const {
-    return _lgrid[fieldId];
+  const petrimaps::Grid<ID_TYPE, float, float>& getLineGrid(size_t lid) const {
+    return _lgrid[_lidToGrid[lid]];
   }
 
   const petrimaps::Grid<util::geo::Point<uint8_t>, float, float>&
-  getLinePointGrid(size_t fieldId) const {
-    return _lpgrid[fieldId];
+  getLinePointGrid(size_t lid) const {
+    return _lpgrid[_lidToGrid[lid]];
   }
 
-  const petrimaps::Grid<ID_TYPE, float, float>& getAreaGrid(
-      size_t fieldId) const {
-    return _agrid[fieldId];
+  const petrimaps::Grid<ID_TYPE, float, float>& getAreaGrid(size_t lid) const {
+    return _agrid[_lidToGrid[lid]];
   }
 
-  const std::vector<std::pair<ID_TYPE, ID_TYPE>>& getObjects(
-      size_t fieldId) const {
-    return _objects[fieldId];
+  const std::vector<std::pair<ID_TYPE, ID_TYPE>>& getObjects(size_t lid) const {
+    return _objects[_lidToObject[lid]];
   }
 
   const std::vector<std::pair<util::geo::FPoint, ID_TYPE>>& getDynamicPoints(
-      size_t fieldId) const {
-    return _dynamicPoints[fieldId];
+      size_t lid) const {
+    return _dynamicPoints[_lidToObject[lid]];
   }
 
   const std::vector<std::pair<ID_TYPE, std::pair<size_t, size_t>>>& getClusters(
-      size_t fieldId) const {
-    return _clusterObjects[fieldId];
+      size_t lid) const {
+    return _clusterObjects[_lidToObject[lid]];
   }
 
   const std::pair<ID_TYPE, std::pair<size_t, size_t>>& getCluster(
-      size_t fieldId, size_t oid) const {
-    size_t cid =
-        oid - _objects[fieldId].size() - _dynamicPoints[fieldId].size();
-    return _clusterObjects[fieldId][cid];
+      size_t lid, size_t oid) const {
+    const size_t gid = _lidToObject[lid];
+    size_t cid = oid - _objects[gid].size() - _dynamicPoints[gid].size();
+    return _clusterObjects[gid][cid];
   }
 
-  const util::geo::FPoint& getCPoint(size_t fieldId, ID_TYPE oid) const {
-    return _cache->getPoints()[_objects[fieldId][oid].first];
+  const util::geo::FPoint& getCPoint(size_t lid, ID_TYPE oid) const {
+    return _cache->getPoints()[_objects[_lidToObject[lid]][oid].first];
   }
 
-  const util::geo::FPoint& getDPoint(size_t fieldId, ID_TYPE oid) const {
-    return _dynamicPoints[fieldId][oid - _objects[fieldId].size()].first;
+  const util::geo::FPoint& getDPoint(size_t lid, ID_TYPE oid) const {
+    const size_t gid = _lidToObject[lid];
+    return _dynamicPoints[gid][oid - _objects[gid].size()].first;
   }
 
-  const util::geo::FPoint& getPoint(size_t fieldId, ID_TYPE oid) const {
-    if (oid < _objects[fieldId].size()) return getCPoint(fieldId, oid);
-    return getDPoint(fieldId, oid);
+  const util::geo::FPoint& getPoint(size_t lid, ID_TYPE oid) const {
+    if (oid < _objects[_lidToObject[lid]].size()) return getCPoint(lid, oid);
+    return getDPoint(lid, oid);
   }
 
-  size_t getRow(size_t fieldId, ID_TYPE oid) const {
-    if (isCluster(fieldId, oid)) oid = getCluster(fieldId, oid).first;
-    if (oid >= _objects[fieldId].size())
-      return _dynamicPoints[fieldId][oid - _objects[fieldId].size()].second;
-    return _objects[fieldId][oid].second;
+  size_t getRow(size_t lid, ID_TYPE oid) const {
+    const size_t gid = _lidToObject[lid];
+    if (isCluster(lid, oid)) oid = getCluster(lid, oid).first;
+    if (oid >= _objects[gid].size())
+      return _dynamicPoints[gid][oid - _objects[gid].size()].second;
+    return _objects[gid][oid].second;
   }
 
-  bool isCluster(size_t fieldId, ID_TYPE id) const {
-    return id >= getObjects(fieldId).size() + getDynamicPoints(fieldId).size();
+  bool isCluster(size_t lid, ID_TYPE id) const {
+    return id >= getObjects(lid).size() + getDynamicPoints(lid).size();
   }
 
   size_t getLine(ID_TYPE id) const { return _cache->getLine(id); }
@@ -218,15 +240,18 @@ class Requestor {
   bool isArea(size_t lineId) const;
   bool isInnerArea(size_t lineId) const;
 
+  // total number of objects over all distinct geometry columns
   size_t getNumObjects() const {
     size_t ret = 0;
-    for (size_t lid = 0; lid < _numObjects.size(); lid++)
-      ret += _numObjects[lid];
+    for (size_t gid = 0; gid < _numObjects.size(); gid++)
+      ret += _numObjects[gid];
 
     return ret;
   }
-  size_t getNumObjects(size_t lid) const { return _numObjects[lid]; }
-  util::geo::DPoint clusterGeom(size_t fieldId, size_t oid, double res) const;
+  size_t getNumObjects(size_t lid) const {
+    return _numObjects[_lidToObject[lid]];
+  }
+  util::geo::DPoint clusterGeom(size_t lid, size_t oid, double res) const;
 
   static std::vector<std::string> getColumns(const std::string& backend,
                                              std::string query);
@@ -235,21 +260,21 @@ class Requestor {
   std::pair<double, double> getRasterMetas(size_t lid, size_t oid,
                                            std::pair<double, double> def) const;
 
-  size_t getNumFields() const { return _pgrid.size(); }
+  size_t getNumLayers() const { return _layers.size(); }
   bool lineIntersects(size_t lid, const util::geo::DBox& bbox) const;
 
-  const std::vector<FieldConfig>& getFields() const { return _fields; }
+  const std::vector<LayerConfig>& getLayers() const { return _layers; }
 
-  size_t getFieldById(const std::string& id) {
+  size_t getLidById(const std::string& id) {
     auto it = _layerIdToLid.find(id);
     if (it == _layerIdToLid.end()) {
       std::stringstream ss;
-      ss << "Field '" << id << "' not found";
+      ss << "Layer '" << id << "' not found";
       throw std::runtime_error(ss.str());
     }
     return it->second;
   }
-  std::pair<double, double> getValRange(size_t fid) const;
+  std::pair<double, double> getValRange(size_t lid) const;
 
   std::chrono::time_point<std::chrono::system_clock> createdAt() const {
     return _createdAt;
@@ -267,7 +292,7 @@ class Requestor {
 
   std::shared_ptr<const GeomCache> _cache;
   RequestorConfig _rcfg;
-  std::vector<FieldConfig> _fields;
+  std::vector<LayerConfig> _layers;
 
   size_t _maxMemory;
 
@@ -278,29 +303,54 @@ class Requestor {
   std::vector<std::pair<util::geo::FPoint, ID_TYPE>> getDynamicPoints(
       const std::vector<IdMapping>& ids) const;
 
+  static size_t uniqueCol(const std::string& col,
+                          std::vector<std::string>* cols,
+                          std::map<std::string, size_t>* idx) {
+    auto it = idx->find(col);
+    if (it != idx->end()) return it->second;
+
+    cols->push_back(col);
+    (*idx)[col] = cols->size() - 1;
+    return cols->size() - 1;
+  }
+
+  // value of object oid of geom column gid, taken from value column vid
+  double getValFor(size_t gid, size_t vid, size_t oid) const;
+
   std::string _query, _sortColumn;
 
   mutable std::mutex _m;
 
+  // per distinct geometry column
   std::vector<std::vector<std::pair<ID_TYPE, ID_TYPE>>> _objects;
   std::vector<std::vector<std::pair<util::geo::FPoint, ID_TYPE>>>
       _dynamicPoints;
   std::vector<std::vector<std::pair<ID_TYPE, std::pair<size_t, size_t>>>>
       _clusterObjects;
+  std::vector<size_t> _numObjects;
+
+  // per vid
   std::vector<std::vector<double>> _vals;
   std::vector<double> _valsMax;
   std::vector<double> _valsMin;
+
+  // per rid
   std::vector<std::vector<size_t>> _rasterMetas;
-  std::vector<size_t> _numObjects;
 
   std::vector<std::string> _geomColumns;
   std::vector<std::string> _valueColumns;
   std::vector<std::string> _rasterMetaColumns;
   std::map<std::string, size_t> _columnsMap;
-  std::map<std::string, size_t> _geoColToLid;
   std::map<std::string, size_t> _layerIdToLid;
-  std::map<size_t, size_t> _valueFlds;
-  std::map<size_t, size_t> _rasterMetaFlds;
+
+  // per (gid, vid)
+  std::vector<std::pair<size_t, size_t>> _gridSets;
+
+  // mapping indirection  lid -> gid, vid, rad, grid
+  std::vector<size_t> _lidToObject;
+  std::vector<size_t> _lidToValue;
+  std::vector<size_t> _lidToRaster;
+  std::vector<size_t> _lidToGrid;
 
   std::vector<petrimaps::Grid<ID_TYPE, float, float>> _pgrid;
   std::vector<petrimaps::Grid<ID_TYPE, float, float>> _lgrid;

--- a/src/qlever-petrimaps/server/Requestor.h
+++ b/src/qlever-petrimaps/server/Requestor.h
@@ -18,6 +18,7 @@
 #include "qlever-petrimaps/GeomCache.h"
 #include "qlever-petrimaps/Grid.h"
 #include "qlever-petrimaps/Misc.h"
+#include "qlever-petrimaps/server/RenderContext.h"
 #include "util/geo/Geo.h"
 #include "util/log/Log.h"
 
@@ -38,6 +39,7 @@ struct LayerConfig {
   std::string color = "3388ff";
   std::string colorscheme = "spectralexp";
   std::string style = "auto";
+  ObjectStyle objectStyle;
 };
 
 struct RequestorConfig {
@@ -124,9 +126,10 @@ class Requestor {
 
     LOG(util::LogLevel::INFO)
         << "[REQUESTOR] " << _layers.size() << " layers, "
-        << _geomColumns.size() << " geom columns, " << _valueColumns.size()
-        << " value columns, " << _rasterMetaColumns.size()
-        << " raster columns, " << _gridSets.size() << " grid sets";
+        << _geomColumns.size() << " unique geom columns, "
+        << _valueColumns.size() << " unique value columns, "
+        << _rasterMetaColumns.size() << " raster columns, " << _gridSets.size()
+        << " unique grid sets";
   }
 
   void request(const std::string& remoteAddr);

--- a/src/qlever-petrimaps/server/Requestor.h
+++ b/src/qlever-petrimaps/server/Requestor.h
@@ -121,6 +121,7 @@ class Requestor {
 
       _layers.push_back(layer);
       _layerIdToLid[layer.id] = _layers.size() - 1;
+      _geomFieldToLid[layer.geomField].push_back(_layers.size() - 1);
 
       _lidToObject.push_back(gid);
       _lidToValue.push_back(vid);
@@ -229,10 +230,6 @@ class Requestor {
                           double res, util::geo::FBox box,
                           const std::string& remoteAddr) const;
 
-  const ResObj getNearest(util::geo::DPoint p, double rad, double res,
-                          util::geo::FBox box,
-                          const std::string& remoteAddr) const;
-
   const ResObj getGeom(size_t lid, size_t id, double rad) const;
 
   util::geo::MultiPolygon<double> geomPolyGeoms(size_t lid, size_t oid,
@@ -273,8 +270,7 @@ class Requestor {
                                              std::string query);
 
   double getVal(size_t lid, size_t oid) const;
-  std::pair<double, double> getRasterMetas(size_t lid, size_t oid,
-                                           std::pair<double, double> def) const;
+  std::pair<double, double> getRasterMetas(size_t lid, size_t oid) const;
 
   size_t getNumLayers() const { return _layers.size(); }
   bool lineIntersects(size_t lid, const util::geo::DBox& bbox) const;
@@ -290,6 +286,22 @@ class Requestor {
     }
     return it->second;
   }
+
+  size_t getLidByGeomField(const std::string& field) {
+    auto it = _geomFieldToLid.find(field);
+    if (it == _geomFieldToLid.end()) {
+      std::stringstream ss;
+      ss << "Geom field '" << field << "' not found";
+      throw std::runtime_error(ss.str());
+    }
+    if (it->second.size() == 0) {
+      std::stringstream ss;
+      ss << "Geom field '" << field << "' not found";
+      throw std::runtime_error(ss.str());
+    }
+    return it->second[0];
+  }
+
   std::pair<double, double> getValRange(size_t lid) const;
 
   std::chrono::time_point<std::chrono::system_clock> createdAt() const {
@@ -362,11 +374,14 @@ class Requestor {
   // per (gid, vid)
   std::vector<std::pair<size_t, size_t>> _gridSets;
 
-  // mapping indirection  lid -> gid, vid, rad, grid
+  // mapping in direction  lid -> gid, vid, rad, grid
   std::vector<size_t> _lidToObject;
   std::vector<size_t> _lidToValue;
   std::vector<size_t> _lidToRaster;
   std::vector<size_t> _lidToGrid;
+
+  // mapping geomfield -> lid
+  std::map<std::string, std::vector<size_t>> _geomFieldToLid;
 
   std::vector<petrimaps::Grid<ID_TYPE, float, float>> _pgrid;
   std::vector<petrimaps::Grid<ID_TYPE, float, float>> _lgrid;

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -167,9 +167,6 @@ util::http::Answer Server::handle(const util::http::Req& req, int con) const {
       a = handleClearSessReq(params, req.params, con);
     } else if (cmd == "/clearsessions") {
       a = handleClearSessReq(params, req.params, con);
-    } else if (cmd == "/pos") {
-      LOG(INFO) << "Position request from " << remoteAddress(con, req.params);
-      a = handlePosReq(params, req.params, con);
     } else if (cmd == "/loadstatus") {
       a = handleLoadStatusReq(params, req.params, con);
     } else if (cmd == "/build.js") {
@@ -278,20 +275,27 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
   if (pars.count("layers") == 0 || pars.find("layers")->second.empty())
     throw std::invalid_argument("No layer specified.");
-  std::string layers = pars.find("layers")->second;
+  std::string layersPar = pars.find("layers")->second;
 
-  std::string id;
+  std::string sessionId;
+  std::string geomField;
 
-  auto parts = util::split(layers, ',');
-  if (parts.size() > 1)
+  auto layers = util::split(layersPar, ',');
+  if (layers.size() > 1)
     throw std::invalid_argument("Multiple layers not supported");
+  if (layers.size() == 0)
+    throw std::invalid_argument("No layer specified");
 
-  if (parts.size()) id = parts[0];
+  if (layers.size()) {
+    auto parts = util::split(layers[0], ':');
+    if (parts.size() != 2)
+      throw std::invalid_argument("Invalid layer '" + layers[0] + "' specified");
+    sessionId = parts[0];
+    geomField = parts[1];
+  }
 
   MapStyle style = HEATMAP;
   auto colorScheme = heatmap_cs_Spectral_mixed_exp;
-  double rasterWidth = 10;
-  double rasterHeight = 10;
 
   int objColorR = 0, objColorG = 0, objColorB = 0;
 
@@ -301,27 +305,27 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   std::shared_ptr<Requestor> r;
   {
     std::lock_guard<std::mutex> guard(_m);
-    bool has = _rs.count(id);
+    bool has = _rs.count(sessionId);
     if (!has) {
-      LOG(ERROR) << "Session " << id << " not found!";
+      LOG(ERROR) << "Session " << sessionId << " not found!";
       throw std::invalid_argument("Session not found");
     }
-    r = _rs[id];
+    r = _rs[sessionId];
   }
 
   if (!r->ready()) {
-    LOG(ERROR) << "Session " << id << " not ready!";
+    LOG(ERROR) << "Session " << sessionId << " not ready!";
     throw std::invalid_argument("Session not ready.");
   }
 
   if (pars.count("styles") != 0 && !pars.find("styles")->second.empty()) {
-    auto layerId = pars.find("styles")->second;
-    lid = r->getLidById(layerId);
+    auto styleId = pars.find("styles")->second;
+    lid = r->getLidById(styleId);
   }
 
   if (box.size() != 4) throw std::invalid_argument("Invalid request.");
 
-  LOG(INFO) << "[SERVER] Begin heatmap generation for session " << id;
+  LOG(INFO) << "[SERVER] Begin heatmap generation for session " << sessionId << " on geom field " << geomField;;
 
   double x1 = std::atof(box[0].c_str());
   double y1 = std::atof(box[1].c_str());
@@ -347,20 +351,13 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
   lcfg = r->getLayers()[lid];
 
+  if (lcfg.geomField != geomField) throw std::invalid_argument("Style not defined for geom field '" + geomField + "', but for '" + lcfg.geomField + "'");
+
   if (lcfg.style == "objects") style = OBJECTS;
   if (lcfg.style == "raster") style = RASTER;
   if (lcfg.style == "auto" && res < THRESHOLD &&
       r->getNumObjects(lid) > _autoThreshold)
     style = OBJECTS;
-
-  if (style == RASTER && parts.size() > 1) {
-    // in web mercator units (pseudometers)!
-    auto xy = util::split(parts[1], 'x');
-    if (xy.size() > 1) {
-      rasterWidth = ::atof(xy[0].c_str());
-      rasterHeight = ::atof(xy[1].c_str());
-    }
-  }
 
   if (style == OBJECTS) {
     if (lcfg.color.size() == 6) {
@@ -474,7 +471,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
           if (style == RASTER) {
             auto rasterMeta =
-                r->getRasterMetas(lid, oid, {rasterWidth, rasterHeight});
+                r->getRasterMetas(lid, oid);
             rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(lid, oid),
                                rasterMeta.first, rasterMeta.second);
           } else {
@@ -517,7 +514,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
               if (style == RASTER) {
                 auto rasterMeta =
-                    r->getRasterMetas(lid, oid, {rasterWidth, rasterHeight});
+                    r->getRasterMetas(lid, oid);
                 rcontext.drawPoint(tid, px.getX(), px.getY(),
                                    r->getVal(lid, oid), rasterMeta.first,
                                    rasterMeta.second);
@@ -588,8 +585,8 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
             auto pix = RenderContext::mercToPx(cellBox.getLowerLeft(), orx, ory,
                                                mercW, mercH, w, h);
             rcontext.drawLinePoint(tid, pix.getX(), pix.getY(),
-                                   lpgrid.getCellSum(x, y), rasterWidth,
-                                   rasterHeight);
+                                   lpgrid.getCellSum(x, y), 1,
+                                   1);
           } else {
             for (const auto& p : *cell) {
               int px = ((cellBox.getLowerLeft().getX() + p.getX() * 256 -
@@ -600,7 +597,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
                              bbox.getLowerLeft().getY()) /
                             mercH) *
                                h;
-              rcontext.drawLinePoint(tid, px, py, 1, rasterWidth, rasterHeight);
+              rcontext.drawLinePoint(tid, px, py, 1, 1, 1);
             }
           }
         }
@@ -769,10 +766,11 @@ std::string lower(std::string s) {
   return s;
 }
 
+// _____________________________________________________________________________
 const std::string* getParamCaseInsensitive(const Params& pars,
                                            const std::string& key) {
   for (const auto& entry : pars) {
-    if (lower(entry.first) == key) {
+    if (lower(entry.first) == lower(key)) {
       return &entry.second;
     }
   }
@@ -1360,16 +1358,11 @@ util::http::Answer Server::handleWFSGetFeatureReq(
     throw std::invalid_argument("Unsupported WFS version.");
   }
 
-  if (getParamCaseInsensitive(pars, "x") != nullptr &&
-      getParamCaseInsensitive(pars, "y") != nullptr &&
-      getParamCaseInsensitive(pars, "rad") != nullptr) {
-    return handleWFSPickFeatureReq(pars, headerPars, sock);
-  }
-
-  std::string typeName;
+  std::string typeName, sessionId, geomField;
   const std::string* typeNamesParam =
       getParamCaseInsensitive(pars, "typenames");
   const std::string* typeNameParam = getParamCaseInsensitive(pars, "typename");
+
   if (typeNamesParam != nullptr && !typeNamesParam->empty()) {
     typeName = *typeNamesParam;
   } else if (typeNameParam != nullptr && !typeNameParam->empty()) {
@@ -1378,12 +1371,13 @@ util::http::Answer Server::handleWFSGetFeatureReq(
     throw std::invalid_argument("No WFS typename specified.");
   }
 
+  auto parts = util::split(typeName, ':');
+  if (parts.size() != 2)
+    throw std::invalid_argument("Invalid type name '" + typeName + "' specified");
+
+  sessionId = parts[0];
+  geomField = parts[1];
   std::shared_ptr<Requestor> reqor;
-  std::string sessionId = typeName;
-  const std::string prefix = "session_";
-  if (sessionId.rfind(prefix, 0) == 0) {
-    sessionId = sessionId.substr(prefix.size());
-  }
 
   bool found = false;
   {
@@ -1407,14 +1401,7 @@ util::http::Answer Server::handleWFSGetFeatureReq(
     throw std::invalid_argument("No fields found for WFS type name.");
   }
 
-  size_t lid;
-
-  const std::string* geomFieldParam = getParamCaseInsensitive(pars, "layerid");
-  if (geomFieldParam != nullptr && !geomFieldParam->empty()) {
-    lid = reqor->getLidById(*geomFieldParam);
-  } else {
-    lid = reqor->getLidById(fields[0].id);
-  }
+  size_t lid = reqor->getLidByGeomField(geomField);
 
   auto layerCfg = reqor->getLayers()[lid];
 
@@ -1452,8 +1439,8 @@ util::http::Answer Server::handleWFSGetFeatureReq(
 
   bool hasBbox = false;
   bool fullExport = false;
-  FBox fbbox;
   DBox dbbox;
+  FBox fbbox;
 
   const std::string* bboxParam = getParamCaseInsensitive(pars, "bbox");
   const std::string* gidParam = getParamCaseInsensitive(pars, "gid");
@@ -1510,7 +1497,7 @@ util::http::Answer Server::handleWFSGetFeatureReq(
 
   std::vector<size_t> featureIds;
 
-   if (hasBbox) {
+  if (hasBbox) {
     // select by bounding box
     std::unordered_set<ID_TYPE> candidates;
 
@@ -1522,28 +1509,26 @@ util::http::Answer Server::handleWFSGetFeatureReq(
       reqor->getLineGrid(lid).get(fbbox, &candidates);
     }
 
-    std::vector<ID_TYPE> sortedCandidates(candidates.begin(), candidates.end());
-    std::sort(sortedCandidates.begin(), sortedCandidates.end());
+    for (const auto& cand : candidates) {
+      auto oid = reqor->getObjects(lid)[cand].second;
+      auto geomId = reqor->getObjects(lid)[cand].first;
 
-    for (auto candidateOid : sortedCandidates) {
-      size_t oid = candidateOid;
       if (reqor->isCluster(lid, oid)) oid = reqor->getCluster(lid, oid).first;
-      if (oid >= reqor->getNumObjects(lid)) continue;
 
       bool include = false;
 
-      if (oid < reqor->getObjects(lid).size()) {
-        auto geomId = reqor->getObjects(lid)[oid].first;
-
-        if (geomId < I_OFFSET) {
-          auto p = reqor->getPoint(lid, oid);
-          include = contains(p, fbbox);
-        } else {
-          include = reqor->lineIntersects(geomId, dbbox);
-        }
-      } else {
+      if (geomId < I_OFFSET) {
         auto p = reqor->getPoint(lid, oid);
         include = contains(p, fbbox);
+      } else {
+        size_t lineId = geomId - I_OFFSET;
+
+        if (reqor->isArea(lineId)) {
+          const auto& dline = reqor->extractLineGeom(lineId);
+          include = util::geo::intersects(dbbox, util::geo::DPolygon(dline));
+        } else  {
+          include = reqor->lineIntersects(lineId, dbbox);
+        }
       }
 
       if (include) {
@@ -1837,13 +1822,6 @@ util::http::Answer Server::handleTMSReq(const Params& pars, int sock) const {
 }
 
 // _____________________________________________________________________________
-util::http::Answer Server::handlePosReq(const Params& pars,
-                                        const HeaderParams& headers,
-                                        int sock) const {
-  return handleNearestFeatureReq(pars, headers, sock, false);
-}
-
-// _____________________________________________________________________________
 util::http::Answer Server::handleTouchReq(const Params& pars,
                                           const HeaderParams& headerParams,
                                           int sock) const {
@@ -1903,10 +1881,6 @@ util::http::Answer Server::handleNearestFeatureReq(const Params& pars,
     throw std::invalid_argument("No y coord (?y=) specified.");
   float y = std::atof(pars.find("y")->second.c_str());
 
-  if (pars.count("id") == 0 || pars.find("id")->second.empty())
-    throw std::invalid_argument("No session id (?id=) specified.");
-  auto id = pars.find("id")->second;
-
   if (pars.count("rad") == 0 || pars.find("rad")->second.empty())
     throw std::invalid_argument("No rad (?rad=) specified.");
   float rad = std::atof(pars.find("rad")->second.c_str());
@@ -1919,6 +1893,26 @@ util::http::Answer Server::handleNearestFeatureReq(const Params& pars,
   if (pars.count("bbox") == 0 || pars.find("bbox")->second.empty())
     throw std::invalid_argument("No bbox specified.");
   auto box = util::split(pars.find("bbox")->second, ',');
+
+  std::string typeName, sessionId, geomField;
+  const std::string* typeNamesParam =
+      getParamCaseInsensitive(pars, "typenames");
+  const std::string* typeNameParam = getParamCaseInsensitive(pars, "typename");
+
+  if (typeNamesParam != nullptr && !typeNamesParam->empty()) {
+    typeName = *typeNamesParam;
+  } else if (typeNameParam != nullptr && !typeNameParam->empty()) {
+    typeName = *typeNameParam;
+  } else {
+    throw std::invalid_argument("No WFS typename specified.");
+  }
+
+  auto parts = util::split(typeName, ':');
+  if (parts.size() != 2)
+    throw std::invalid_argument("Invalid type name '" + typeName + "' specified");
+
+  sessionId = parts[0];
+  geomField = parts[1];
 
   if (box.size() != 4) throw std::invalid_argument("Invalid request.");
   if (isWfsRequest) {
@@ -1956,21 +1950,24 @@ util::http::Answer Server::handleNearestFeatureReq(const Params& pars,
   std::shared_ptr<Requestor> reqor;
   {
     std::lock_guard<std::mutex> guard(_m);
-    bool has = _rs.count(id);
+    bool has = _rs.count(sessionId);
     if (!has) {
-      LOG(ERROR) << "Session " << id << " not found!";
+      LOG(ERROR) << "Session " << sessionId << " not found!";
       throw std::invalid_argument("Session not found");
     }
-    reqor = _rs[id];
+    reqor = _rs[sessionId];
   }
 
   if (!reqor->ready()) {
     throw std::invalid_argument("Session not ready.");
   }
+
+  size_t lid = reqor->getLidByGeomField(geomField);
+
   // as soon as we are ready, the reqor can be read concurrently
 
   LOG(INFO) << "Looking up nearest geometry...";
-  auto res = reqor->getNearest({x, y}, rad, reso, fbbox, remoteAddr);
+  auto res = reqor->getNearest(lid, {x, y}, rad, reso, fbbox, remoteAddr);
   LOG(INFO) << "Got nearest geometry...";
 
   if (isWfsRequest) {

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -196,8 +196,8 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
   int objColorR = 0, objColorG = 0, objColorB = 0;
 
-  FieldConfig fcfg;
-  size_t fid = 0;
+  LayerConfig lcfg;
+  size_t lid = 0;
 
   std::shared_ptr<Requestor> r;
   {
@@ -217,13 +217,13 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
   if (pars.count("styles") != 0 && !pars.find("styles")->second.empty()) {
     auto layerId = pars.find("styles")->second;
-    fid = r->getFieldById(layerId);
+    lid = r->getLidById(layerId);
   }
 
-  fcfg = r->getFields()[fid];
+  lcfg = r->getLayers()[lid];
 
-  if (fcfg.style == "objects") style = OBJECTS;
-  if (fcfg.style == "raster") style = RASTER;
+  if (lcfg.style == "objects") style = OBJECTS;
+  if (lcfg.style == "raster") style = RASTER;
 
   if (style == RASTER && parts.size() > 1) {
     // in web mercator units (pseudometers)!
@@ -235,60 +235,60 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   }
 
   if (style == OBJECTS) {
-    if (fcfg.color.size() == 6) {
-      objColorR = hexToInt(fcfg.color[0]) * 16 + hexToInt(fcfg.color[1]);
-      objColorG = hexToInt(fcfg.color[2]) * 16 + hexToInt(fcfg.color[3]);
-      objColorB = hexToInt(fcfg.color[4]) * 16 + hexToInt(fcfg.color[5]);
+    if (lcfg.color.size() == 6) {
+      objColorR = hexToInt(lcfg.color[0]) * 16 + hexToInt(lcfg.color[1]);
+      objColorG = hexToInt(lcfg.color[2]) * 16 + hexToInt(lcfg.color[3]);
+      objColorB = hexToInt(lcfg.color[4]) * 16 + hexToInt(lcfg.color[5]);
     }
   }
 
   if (style == HEATMAP) {
-    if (fcfg.colorscheme == "spectralexp")
+    if (lcfg.colorscheme == "spectralexp")
       colorScheme = heatmap_cs_Spectral_mixed_exp;
-    if (fcfg.colorscheme == "spectral") colorScheme = heatmap_cs_Spectral_mixed;
-    if (fcfg.colorscheme == "RdYlGn") colorScheme = heatmap_cs_RdYlGn_mixed;
-    if (fcfg.colorscheme == "RdYlGnexp")
+    if (lcfg.colorscheme == "spectral") colorScheme = heatmap_cs_Spectral_mixed;
+    if (lcfg.colorscheme == "RdYlGn") colorScheme = heatmap_cs_RdYlGn_mixed;
+    if (lcfg.colorscheme == "RdYlGnexp")
       colorScheme = heatmap_cs_RdYlGn_mixed_exp;
-    if (fcfg.colorscheme == "w2b") colorScheme = heatmap_cs_w2b_opaque;
-    if (fcfg.colorscheme == "b2w") colorScheme = heatmap_cs_b2w_opaque;
-    if (fcfg.colorscheme == "RdYlBu") colorScheme = heatmap_cs_RdYlBu_mixed;
-    if (fcfg.colorscheme == "RdGy") colorScheme = heatmap_cs_RdGy_mixed;
-    if (fcfg.colorscheme == "YlOrRd") colorScheme = heatmap_cs_YlOrRd_mixed;
-    if (fcfg.colorscheme == "Blues") colorScheme = heatmap_cs_Blues_mixed;
-    if (fcfg.colorscheme == "Greens") colorScheme = heatmap_cs_Greens_mixed;
-    if (fcfg.colorscheme == "Greys") colorScheme = heatmap_cs_Greys_mixed;
-    if (fcfg.colorscheme == "Oranges") colorScheme = heatmap_cs_Oranges_mixed;
-    if (fcfg.colorscheme == "Reds") colorScheme = heatmap_cs_Reds_mixed;
+    if (lcfg.colorscheme == "w2b") colorScheme = heatmap_cs_w2b_opaque;
+    if (lcfg.colorscheme == "b2w") colorScheme = heatmap_cs_b2w_opaque;
+    if (lcfg.colorscheme == "RdYlBu") colorScheme = heatmap_cs_RdYlBu_mixed;
+    if (lcfg.colorscheme == "RdGy") colorScheme = heatmap_cs_RdGy_mixed;
+    if (lcfg.colorscheme == "YlOrRd") colorScheme = heatmap_cs_YlOrRd_mixed;
+    if (lcfg.colorscheme == "Blues") colorScheme = heatmap_cs_Blues_mixed;
+    if (lcfg.colorscheme == "Greens") colorScheme = heatmap_cs_Greens_mixed;
+    if (lcfg.colorscheme == "Greys") colorScheme = heatmap_cs_Greys_mixed;
+    if (lcfg.colorscheme == "Oranges") colorScheme = heatmap_cs_Oranges_mixed;
+    if (lcfg.colorscheme == "Reds") colorScheme = heatmap_cs_Reds_mixed;
 
-    if (fcfg.colorscheme == "RdYlBuexp")
+    if (lcfg.colorscheme == "RdYlBuexp")
       colorScheme = heatmap_cs_RdYlBu_mixed_exp;
-    if (fcfg.colorscheme == "RdGyexp") colorScheme = heatmap_cs_RdGy_mixed_exp;
-    if (fcfg.colorscheme == "YlOrRdexp")
+    if (lcfg.colorscheme == "RdGyexp") colorScheme = heatmap_cs_RdGy_mixed_exp;
+    if (lcfg.colorscheme == "YlOrRdexp")
       colorScheme = heatmap_cs_YlOrRd_mixed_exp;
-    if (fcfg.colorscheme == "Bluesexp")
+    if (lcfg.colorscheme == "Bluesexp")
       colorScheme = heatmap_cs_Blues_mixed_exp;
-    if (fcfg.colorscheme == "Greensexp")
+    if (lcfg.colorscheme == "Greensexp")
       colorScheme = heatmap_cs_Greens_mixed_exp;
-    if (fcfg.colorscheme == "Greysexp")
+    if (lcfg.colorscheme == "Greysexp")
       colorScheme = heatmap_cs_Greys_mixed_exp;
-    if (fcfg.colorscheme == "Orangesexp")
+    if (lcfg.colorscheme == "Orangesexp")
       colorScheme = heatmap_cs_Oranges_mixed_exp;
-    if (fcfg.colorscheme == "Redsexp") colorScheme = heatmap_cs_Reds_mixed_exp;
+    if (lcfg.colorscheme == "Redsexp") colorScheme = heatmap_cs_Reds_mixed_exp;
   }
 
   if (style == RASTER) {
-    if (fcfg.colorscheme == "spectral")
+    if (lcfg.colorscheme == "spectral")
       colorScheme = heatmap_cs_Spectral_discrete;
-    if (fcfg.colorscheme == "RdYlGn") colorScheme = heatmap_cs_RdYlGn_discrete;
-    if (fcfg.colorscheme == "RdYlBu") colorScheme = heatmap_cs_RdYlBu_discrete;
-    if (fcfg.colorscheme == "RdGy") colorScheme = heatmap_cs_RdGy_discrete;
-    if (fcfg.colorscheme == "YlOrRd") colorScheme = heatmap_cs_YlOrRd_discrete;
-    if (fcfg.colorscheme == "Blues") colorScheme = heatmap_cs_Blues_discrete;
-    if (fcfg.colorscheme == "Greens") colorScheme = heatmap_cs_Greens_discrete;
-    if (fcfg.colorscheme == "Greys") colorScheme = heatmap_cs_Greys_discrete;
-    if (fcfg.colorscheme == "Oranges")
+    if (lcfg.colorscheme == "RdYlGn") colorScheme = heatmap_cs_RdYlGn_discrete;
+    if (lcfg.colorscheme == "RdYlBu") colorScheme = heatmap_cs_RdYlBu_discrete;
+    if (lcfg.colorscheme == "RdGy") colorScheme = heatmap_cs_RdGy_discrete;
+    if (lcfg.colorscheme == "YlOrRd") colorScheme = heatmap_cs_YlOrRd_discrete;
+    if (lcfg.colorscheme == "Blues") colorScheme = heatmap_cs_Blues_discrete;
+    if (lcfg.colorscheme == "Greens") colorScheme = heatmap_cs_Greens_discrete;
+    if (lcfg.colorscheme == "Greys") colorScheme = heatmap_cs_Greys_discrete;
+    if (lcfg.colorscheme == "Oranges")
       colorScheme = heatmap_cs_Oranges_discrete;
-    if (fcfg.colorscheme == "Reds") colorScheme = heatmap_cs_Reds_discrete;
+    if (lcfg.colorscheme == "Reds") colorScheme = heatmap_cs_Reds_discrete;
   }
 
   if (box.size() != 4) throw std::invalid_argument("Invalid request.");
@@ -318,7 +318,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   double res = mercH / h;
 
   checkMem(sizeof(float) * w * h, _maxMemory);
-  double realCellSize = r->getPointGrid(fid).getCellWidth();
+  double realCellSize = r->getPointGrid(lid).getCellWidth();
   double virtCellSize = res * 1.5;
 
   size_t NUM_THREADS = std::thread::hardware_concurrency();
@@ -338,55 +338,55 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
                          NUM_THREADS);
 
   // POINTS
-  if (intersects(r->getPointGrid(fid).getBBox(), fbbox)) {
+  if (intersects(r->getPointGrid(lid).getBBox(), fbbox)) {
     LOG(INFO) << "[SERVER] Looking up display points...";
     if (res < THRESHOLD) {
       std::vector<ID_TYPE> ret;
 
       // duplicates are not possible with points, so no sorting here
-      r->getPointGrid(fid).get(fbbox, &ret);
+      r->getPointGrid(lid).get(fbbox, &ret);
 
       for (size_t j = 0; j < ret.size(); j++) {
         size_t oid = ret[j];
 
-        if (r->isCluster(fid, oid) && style == OBJECTS) {
-          size_t refOid = r->getCluster(fid, oid).first;
+        if (r->isCluster(lid, oid) && style == OBJECTS) {
+          size_t refOid = r->getCluster(lid, oid).first;
 
-          FPoint p = r->getPoint(fid, refOid);
+          FPoint p = r->getPoint(lid, refOid);
           if (!contains(p, fbbox)) continue;
 
-          const auto& cp = r->clusterGeom(fid, oid, res);
+          const auto& cp = r->clusterGeom(lid, oid, res);
 
           auto px = RenderContext::mercToPx(cp, orx, ory, mercW, mercH, w, h);
           auto ppx = RenderContext::mercToPx(p, orx, ory, mercW, mercH, w, h);
 
-          rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(fid, oid), 0, 0,
+          rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(lid, oid), 0, 0,
                              1);
           rcontext.drawLineSegment(px.getX(), px.getY(), ppx.getX(), ppx.getY(),
                                    w, h);
         } else {
-          if (r->isCluster(fid, oid)) oid = r->getCluster(fid, oid).first;
+          if (r->isCluster(lid, oid)) oid = r->getCluster(lid, oid).first;
 
-          FPoint p = r->getPoint(fid, oid);
+          FPoint p = r->getPoint(lid, oid);
           if (!contains(p, fbbox)) continue;
 
           auto px = RenderContext::mercToPx(p, orx, ory, mercW, mercH, w, h);
 
           if (style == RASTER) {
             auto rasterMeta =
-                r->getRasterMetas(fid, oid, {rasterWidth, rasterHeight});
-            rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(fid, oid),
+                r->getRasterMetas(lid, oid, {rasterWidth, rasterHeight});
+            rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(lid, oid),
                                rasterMeta.first, rasterMeta.second, 1);
           } else {
-            rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(fid, oid), 0,
+            rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(lid, oid), 0,
                                0, 1);
           }
         }
       }
     } else {
       // they intersect, we checked this above
-      auto iBox = intersection(r->getPointGrid(fid).getBBox(), fbbox);
-      const auto& grid = r->getPointGrid(fid);
+      auto iBox = intersection(r->getPointGrid(lid).getBBox(), fbbox);
+      const auto& grid = r->getPointGrid(lid);
 
 #pragma omp parallel for num_threads(NUM_THREADS) schedule(static)
       for (size_t x = grid.getCellXFromX(iBox.getLowerLeft().getX());
@@ -409,21 +409,21 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
                                1, 1, 0.5);
           } else {
             for (auto oid : *cell) {
-              if (r->isCluster(fid, oid)) oid = r->getCluster(fid, oid).first;
+              if (r->isCluster(lid, oid)) oid = r->getCluster(lid, oid).first;
 
-              FPoint p = r->getPoint(fid, oid);
+              FPoint p = r->getPoint(lid, oid);
               auto px =
                   RenderContext::mercToPx(p, orx, ory, mercW, mercH, w, h);
 
               if (style == RASTER) {
                 auto rasterMeta =
-                    r->getRasterMetas(fid, oid, {rasterWidth, rasterHeight});
+                    r->getRasterMetas(lid, oid, {rasterWidth, rasterHeight});
                 rcontext.drawPoint(tid, px.getX(), px.getY(),
-                                   r->getVal(fid, oid), rasterMeta.first,
+                                   r->getVal(lid, oid), rasterMeta.first,
                                    rasterMeta.second, 0.5);
               } else {
                 rcontext.drawPoint(tid, px.getX(), px.getY(),
-                                   r->getVal(fid, oid), 0, 0, 0.5);
+                                   r->getVal(lid, oid), 0, 0, 0.5);
               }
             }
           }
@@ -433,7 +433,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   }
 
   // LINES
-  const auto& lgrid = r->getLineGrid(fid);
+  const auto& lgrid = r->getLineGrid(lid);
 
   if (intersects(lgrid.getBBox(), fbbox)) {
     LOG(INFO) << "[SERVER] Looking up display lines...";
@@ -448,28 +448,28 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
       for (size_t idx = 0; idx < ret.size(); idx++) {
         if (idx > 0 && ret[idx] == ret[idx - 1]) continue;
-        auto lineId = r->getObjects(fid)[ret[idx]].first;
-        auto oid = r->getObjects(fid)[ret[idx]].second;
+        auto lineId = r->getObjects(lid)[ret[idx]].first;
+        auto oid = r->getObjects(lid)[ret[idx]].second;
         if (!util::geo::intersects(r->getLineBBox(lineId - I_OFFSET), bbox))
           continue;
 
         if (r->isArea(lineId - I_OFFSET) &&
             !r->isInnerArea(lineId - I_OFFSET)) {
           rcontext.drawArea(0, r->extractLineGeom(lineId - I_OFFSET, 3 * res),
-                            r->getVal(fid, oid));
+                            r->getVal(lid, oid));
         } else if (r->isArea(lineId - I_OFFSET) &&
                    r->isInnerArea(lineId - I_OFFSET)) {
           rcontext.drawArea(0, r->extractLineGeom(lineId - I_OFFSET, 3 * res),
-                            r->getVal(fid, oid), true, true);
+                            r->getVal(lid, oid), true, true);
         } else {
           if (!r->lineIntersects(lineId, bbox)) continue;
           rcontext.drawLine(0, r->extractLineGeom(lineId - I_OFFSET, 3 * res),
-                            r->getVal(fid, oid));
+                            r->getVal(lid, oid));
         }
       }
     } else {
-      const auto& lpgrid = r->getLinePointGrid(fid);
-      const auto& agrid = r->getAreaGrid(fid);
+      const auto& lpgrid = r->getLinePointGrid(lid);
+      const auto& agrid = r->getAreaGrid(lid);
       auto iBox = intersection(lpgrid.getBBox(), fbbox);
 
 #pragma omp parallel for num_threads(NUM_THREADS) schedule(static)
@@ -516,13 +516,13 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
       for (size_t idx = 0; idx < ret.size(); idx++) {
         if (idx > 0 && ret[idx] == ret[idx - 1]) continue;
-        auto lineId = r->getObjects(fid)[ret[idx]].first;
-        auto oid = r->getObjects(fid)[ret[idx]].second;
+        auto lineId = r->getObjects(lid)[ret[idx]].first;
+        auto oid = r->getObjects(lid)[ret[idx]].second;
         auto geom = r->extractLineGeom(lineId - I_OFFSET, res);
         if (r->isInnerArea(lineId - I_OFFSET)) {
-          rcontext.drawArea(0, geom, r->getVal(fid, oid), true, true);
+          rcontext.drawArea(0, geom, r->getVal(lid, oid), true, true);
         } else {
-          rcontext.drawArea(0, geom, r->getVal(fid, oid), true);
+          rcontext.drawArea(0, geom, r->getVal(lid, oid), true);
         }
       }
     }
@@ -531,7 +531,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   LOG(INFO) << "[SERVER] Adding points to heatmap...";
   heatmap_t* hm = heatmap_new(w, h);
   heatmap_t* hmInterior = heatmap_new(w, h);
-  hm->max = r->getValRange(fid).second;
+  hm->max = r->getValRange(lid).second;
 
   rcontext.writeHeatmap(hm);
 
@@ -688,20 +688,20 @@ util::http::Answer Server::handleGeoJSONReq(const Params& pars,
     throw std::invalid_argument("Session not ready.");
   }
 
-  size_t fid = reqor->getFieldById(layer);
+  size_t lid = reqor->getLidById(layer);
 
   // as soon as we are ready, the reqor can be read concurrently
-  auto res = reqor->getGeom(fid, gid, rad);
+  auto res = reqor->getGeom(lid, gid, rad);
 
   util::json::Val dict;
 
   if (!noExport) {
     size_t row;
-    if (gid < reqor->getObjects(fid).size()) {
-      row = reqor->getObjects(fid)[gid].second;
-    } else if (gid - reqor->getObjects(fid).size() <
-               reqor->getDynamicPoints(fid).size()) {
-      row = reqor->getDynamicPoints(fid)[gid - reqor->getObjects(fid).size()]
+    if (gid < reqor->getObjects(lid).size()) {
+      row = reqor->getObjects(lid)[gid].second;
+    } else if (gid - reqor->getObjects(lid).size() <
+               reqor->getDynamicPoints(lid).size()) {
+      row = reqor->getDynamicPoints(lid)[gid - reqor->getObjects(lid).size()]
                 .second;
     } else {
       throw std::invalid_argument("Invalid request.");
@@ -821,7 +821,7 @@ util::http::Answer Server::handlePosReq(const Params& pars,
 
   if (res.has) {
     json << "{\"id\" :" << res.id;
-    json << ",\"geomfield\" :\"" << reqor->getFields()[res.fieldId].geomField
+    json << ",\"geomfield\" :\"" << reqor->getLayers()[res.fieldId].geomField
          << "\"";
     json << ",\"attrs\" : [";
 
@@ -1056,9 +1056,9 @@ util::http::Answer Server::handleQueryReq(const Params& pars,
 
   util::geo::FBox bbox;
 
-  for (size_t fid = 0; fid < reqor->getNumFields(); fid++) {
-    bbox = extendBox(reqor->getPointGrid(fid).getBBox(), bbox);
-    bbox = extendBox(reqor->getLineGrid(fid).getBBox(), bbox);
+  for (size_t lid = 0; lid < reqor->getNumLayers(); lid++) {
+    bbox = extendBox(reqor->getPointGrid(lid).getBBox(), bbox);
+    bbox = extendBox(reqor->getLineGrid(lid).getBBox(), bbox);
   }
 
   size_t numObjs = reqor->getNumObjects();
@@ -1078,22 +1078,23 @@ util::http::Answer Server::handleQueryReq(const Params& pars,
        << ",\"autothreshold\":" << _autoThreshold << ",\"layers\": [";
 
   bool first = false;
-  for (size_t fid = 0; fid < reqor->getNumFields(); fid++) {
-    const auto& fld = reqor->getFields()[fid];
+  for (size_t lid = 0; lid < reqor->getNumLayers(); lid++) {
+    const auto& layer = reqor->getLayers()[lid];
     if (first) json << ",";
     first = true;
     json << "{";
-    json << "\"id\":\"" << fld.id << "\",";
-    json << "\"geomfield\":\"" << fld.geomField << "\",";
-    json << "\"name\":\"" << fld.name << "\",";
-    json << "\"group\":\"" << fld.group << "\",";
-    json << "\"color\":\"" << fld.color << "\",";
-    json << "\"colorscheme\":\"" << fld.colorscheme << "\",";
-    json << "\"numobjects\":\"" << reqor->getNumObjects(fid) << "\",";
-    json << "\"style\":\"" << fld.style << "\",";
-    json << "\"toggle\":\"" << fld.toggle << "\"";
-    if (fld.rasterW != 0 && fld.rasterH != 0)
-      json << ",\"rasterw\":" << fld.rasterW << ", \"rasterh\":" << fld.rasterH;
+    json << "\"id\":\"" << layer.id << "\",";
+    json << "\"geomfield\":\"" << layer.geomField << "\",";
+    json << "\"name\":\"" << layer.name << "\",";
+    json << "\"group\":\"" << layer.group << "\",";
+    json << "\"color\":\"" << layer.color << "\",";
+    json << "\"colorscheme\":\"" << layer.colorscheme << "\",";
+    json << "\"numobjects\":\"" << reqor->getNumObjects(lid) << "\",";
+    json << "\"style\":\"" << layer.style << "\",";
+    json << "\"toggle\":\"" << layer.toggle << "\"";
+    if (layer.rasterW != 0 && layer.rasterH != 0)
+      json << ",\"rasterw\":" << layer.rasterW
+           << ", \"rasterh\":" << layer.rasterH;
     json << "}";
   }
 
@@ -1525,8 +1526,6 @@ RequestorConfig Server::getRequestorCfgFromJSON(
     const std::string& jsonStr) const {
   RequestorConfig ret;
 
-  std::multiset<std::string> geomFields;
-
   try {
     nlohmann::json data = nlohmann::json::parse(jsonStr);
 
@@ -1542,19 +1541,10 @@ RequestorConfig Server::getRequestorCfgFromJSON(
               ss << "Could not parse requestor config '" << jsonStr << "'";
               throw std::runtime_error(ss.str());
             }
-            FieldConfig curField;
+            LayerConfig curField;
             if (layer.value().contains("id")) curField.id = layer.value()["id"];
-            if (layer.value().contains("geomfield")) {
+            if (layer.value().contains("geomfield"))
               curField.geomField = layer.value()["geomfield"];
-              if (geomFields.count(curField.geomField)) {
-                geomFields.insert(curField.geomField);
-                curField.geomField =
-                    std::string(layer.value()["geomfield"]) + ":" +
-                    std::to_string(geomFields.count(curField.geomField));
-              } else {
-                geomFields.insert(curField.geomField);
-              }
-            }
             if (layer.value().contains("name"))
               curField.name = layer.value()["name"];
             if (layer.value().contains("weightfield"))
@@ -1578,7 +1568,7 @@ RequestorConfig Server::getRequestorCfgFromJSON(
 
             // always assign an ID
             if (curField.id.size() == 0) curField.id = getFreeLayerId();
-            ret.fields.push_back(curField);
+            ret.layers.push_back(curField);
           }
         }
       }
@@ -1687,37 +1677,33 @@ RequestorConfig Server::getDefaultRequestorCfg(const std::string& backend,
       "Blues",       "Bluesexp",   "Greens", "Greensexp", "Greys",  "Greysexp",
       "Oranges",     "Orangesexp", "Reds",   "Redsexp"};
 
-  FieldConfig autoField;
-  autoField.geomField = cols.back();
-  autoField.id = "auto";
-  autoField.name = "Auto";
-  autoField.group = "Auto";
-  autoField.color = "3388ff";
-  autoField.style = "auto";
+  LayerConfig autoLayer;
+  autoLayer.geomField = cols.back();
+  autoLayer.id = "auto";
+  autoLayer.name = "Auto";
+  autoLayer.group = "Auto";
+  autoLayer.color = "3388ff";
+  autoLayer.style = "auto";
 
-  FieldConfig objectField;
-  autoField.geomField = cols.back();
-  autoField.id = "objects";
-  autoField.name = "Objects";
-  autoField.group = "Objects";
-  autoField.color = "3388ff";
-  autoField.style = "objects";
+  LayerConfig objectLayer;
+  autoLayer.geomField = cols.back();
+  autoLayer.id = "objects";
+  autoLayer.name = "Objects";
+  autoLayer.group = "Objects";
+  autoLayer.color = "3388ff";
+  autoLayer.style = "objects";
 
-  ret.fields.push_back(autoField);
-  ret.fields.push_back(objectField);
-
-  size_t i = 0;
+  ret.layers.push_back(autoLayer);
+  ret.layers.push_back(objectLayer);
 
   for (const auto& heatmapStyle : heatmapStyles) {
-    i++;
-    if (i > 2) break;
-    FieldConfig heatField;
-    heatField.geomField = cols.back();
-    heatField.group = "Heatmap";
-    heatField.id = std::string("heatmap-") + heatmapStyle;
-    heatField.name = heatmapStyle;
-    heatField.colorscheme = heatmapStyle;
-    ret.fields.push_back(heatField);
+    LayerConfig heatLayer;
+    heatLayer.geomField = cols.back();
+    heatLayer.group = "Heatmap";
+    heatLayer.id = std::string("heatmap-") + heatmapStyle;
+    heatLayer.name = heatmapStyle;
+    heatLayer.colorscheme = heatmapStyle;
+    ret.layers.push_back(heatLayer);
   }
 
   return ret;

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -182,11 +182,12 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   std::string layers = pars.find("layers")->second;
 
   std::string id;
-  std::string field;
 
-  auto parts = util::split(layers, '-');
+  auto parts = util::split(layers, ',');
+  if (parts.size() > 1)
+    throw std::invalid_argument("Multiple layers not supported");
+
   if (parts.size()) id = parts[0];
-  if (parts.size() > 1) field = parts[1];
 
   MapStyle style = HEATMAP;
   auto colorScheme = heatmap_cs_Spectral_mixed_exp;
@@ -195,71 +196,8 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
   int objColorR = 0, objColorG = 0, objColorB = 0;
 
-  if (pars.count("styles") != 0 && !pars.find("styles")->second.empty()) {
-    auto parts = util::split(pars.find("styles")->second, '-');
-
-    if (parts[0] == "objects") style = OBJECTS;
-    if (parts[0] == "raster") style = RASTER;
-
-    if (style == RASTER && parts.size() > 1) {
-      // in web mercator units (pseudometers)!
-      auto xy = util::split(parts[1], 'x');
-      if (xy.size() > 1) {
-        rasterWidth = ::atof(xy[0].c_str());
-        rasterHeight = ::atof(xy[1].c_str());
-      }
-    }
-
-    if (style == OBJECTS && parts.size() > 1) {
-      if (parts[1].size() == 6) {
-        objColorR = hexToInt(parts[1][0]) * 16 + hexToInt(parts[1][1]);
-        objColorG = hexToInt(parts[1][2]) * 16 + hexToInt(parts[1][3]);
-        objColorB = hexToInt(parts[1][4]) * 16 + hexToInt(parts[1][5]);
-      }
-    }
-
-    if (style == HEATMAP && parts.size() > 1) {
-      if (parts[1] == "spectralexp")
-        colorScheme = heatmap_cs_Spectral_mixed_exp;
-      if (parts[1] == "spectral") colorScheme = heatmap_cs_Spectral_mixed;
-      if (parts[1] == "RdYlGn") colorScheme = heatmap_cs_RdYlGn_mixed;
-      if (parts[1] == "RdYlGnexp") colorScheme = heatmap_cs_RdYlGn_mixed_exp;
-      if (parts[1] == "w2b") colorScheme = heatmap_cs_w2b_opaque;
-      if (parts[1] == "b2w") colorScheme = heatmap_cs_b2w_opaque;
-      if (parts[1] == "RdYlBu") colorScheme = heatmap_cs_RdYlBu_mixed;
-      if (parts[1] == "RdGy") colorScheme = heatmap_cs_RdGy_mixed;
-      if (parts[1] == "YlOrRd") colorScheme = heatmap_cs_YlOrRd_mixed;
-      if (parts[1] == "Blues") colorScheme = heatmap_cs_Blues_mixed;
-      if (parts[1] == "Greens") colorScheme = heatmap_cs_Greens_mixed;
-      if (parts[1] == "Greys") colorScheme = heatmap_cs_Greys_mixed;
-      if (parts[1] == "Oranges") colorScheme = heatmap_cs_Oranges_mixed;
-      if (parts[1] == "Reds") colorScheme = heatmap_cs_Reds_mixed;
-
-      if (parts[1] == "RdYlBuexp") colorScheme = heatmap_cs_RdYlBu_mixed_exp;
-      if (parts[1] == "RdGyexp") colorScheme = heatmap_cs_RdGy_mixed_exp;
-      if (parts[1] == "YlOrRdexp") colorScheme = heatmap_cs_YlOrRd_mixed_exp;
-      if (parts[1] == "Bluesexp") colorScheme = heatmap_cs_Blues_mixed_exp;
-      if (parts[1] == "Greensexp") colorScheme = heatmap_cs_Greens_mixed_exp;
-      if (parts[1] == "Greysexp") colorScheme = heatmap_cs_Greys_mixed_exp;
-      if (parts[1] == "Orangesexp") colorScheme = heatmap_cs_Oranges_mixed_exp;
-      if (parts[1] == "Redsexp") colorScheme = heatmap_cs_Reds_mixed_exp;
-    }
-
-    if (style == RASTER && parts.size() > 2) {
-      if (parts[2] == "spectral") colorScheme = heatmap_cs_Spectral_discrete;
-      if (parts[2] == "RdYlGn") colorScheme = heatmap_cs_RdYlGn_discrete;
-      if (parts[2] == "RdYlBu") colorScheme = heatmap_cs_RdYlBu_discrete;
-      if (parts[2] == "RdGy") colorScheme = heatmap_cs_RdGy_discrete;
-      if (parts[2] == "YlOrRd") colorScheme = heatmap_cs_YlOrRd_discrete;
-      if (parts[2] == "Blues") colorScheme = heatmap_cs_Blues_discrete;
-      if (parts[2] == "Greens") colorScheme = heatmap_cs_Greens_discrete;
-      if (parts[2] == "Greys") colorScheme = heatmap_cs_Greys_discrete;
-      if (parts[2] == "Oranges") colorScheme = heatmap_cs_Oranges_discrete;
-      if (parts[2] == "Reds") colorScheme = heatmap_cs_Reds_discrete;
-    }
-  }
-
-  if (box.size() != 4) throw std::invalid_argument("Invalid request.");
+  FieldConfig fcfg;
+  size_t fid = 0;
 
   std::shared_ptr<Requestor> r;
   {
@@ -277,7 +215,85 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
     throw std::invalid_argument("Session not ready.");
   }
 
-  LOG(INFO) << "[SERVER] Begin heat for session " << id;
+  if (pars.count("styles") != 0 && !pars.find("styles")->second.empty()) {
+    auto layerId = pars.find("styles")->second;
+    fid = r->getFieldById(layerId);
+  }
+
+  fcfg = r->getFields()[fid];
+
+  if (fcfg.style == "objects") style = OBJECTS;
+  if (fcfg.style == "raster") style = RASTER;
+
+  if (style == RASTER && parts.size() > 1) {
+    // in web mercator units (pseudometers)!
+    auto xy = util::split(parts[1], 'x');
+    if (xy.size() > 1) {
+      rasterWidth = ::atof(xy[0].c_str());
+      rasterHeight = ::atof(xy[1].c_str());
+    }
+  }
+
+  if (style == OBJECTS) {
+    if (fcfg.color.size() == 6) {
+      objColorR = hexToInt(fcfg.color[0]) * 16 + hexToInt(fcfg.color[1]);
+      objColorG = hexToInt(fcfg.color[2]) * 16 + hexToInt(fcfg.color[3]);
+      objColorB = hexToInt(fcfg.color[4]) * 16 + hexToInt(fcfg.color[5]);
+    }
+  }
+
+  if (style == HEATMAP) {
+    if (fcfg.colorscheme == "spectralexp")
+      colorScheme = heatmap_cs_Spectral_mixed_exp;
+    if (fcfg.colorscheme == "spectral") colorScheme = heatmap_cs_Spectral_mixed;
+    if (fcfg.colorscheme == "RdYlGn") colorScheme = heatmap_cs_RdYlGn_mixed;
+    if (fcfg.colorscheme == "RdYlGnexp")
+      colorScheme = heatmap_cs_RdYlGn_mixed_exp;
+    if (fcfg.colorscheme == "w2b") colorScheme = heatmap_cs_w2b_opaque;
+    if (fcfg.colorscheme == "b2w") colorScheme = heatmap_cs_b2w_opaque;
+    if (fcfg.colorscheme == "RdYlBu") colorScheme = heatmap_cs_RdYlBu_mixed;
+    if (fcfg.colorscheme == "RdGy") colorScheme = heatmap_cs_RdGy_mixed;
+    if (fcfg.colorscheme == "YlOrRd") colorScheme = heatmap_cs_YlOrRd_mixed;
+    if (fcfg.colorscheme == "Blues") colorScheme = heatmap_cs_Blues_mixed;
+    if (fcfg.colorscheme == "Greens") colorScheme = heatmap_cs_Greens_mixed;
+    if (fcfg.colorscheme == "Greys") colorScheme = heatmap_cs_Greys_mixed;
+    if (fcfg.colorscheme == "Oranges") colorScheme = heatmap_cs_Oranges_mixed;
+    if (fcfg.colorscheme == "Reds") colorScheme = heatmap_cs_Reds_mixed;
+
+    if (fcfg.colorscheme == "RdYlBuexp")
+      colorScheme = heatmap_cs_RdYlBu_mixed_exp;
+    if (fcfg.colorscheme == "RdGyexp") colorScheme = heatmap_cs_RdGy_mixed_exp;
+    if (fcfg.colorscheme == "YlOrRdexp")
+      colorScheme = heatmap_cs_YlOrRd_mixed_exp;
+    if (fcfg.colorscheme == "Bluesexp")
+      colorScheme = heatmap_cs_Blues_mixed_exp;
+    if (fcfg.colorscheme == "Greensexp")
+      colorScheme = heatmap_cs_Greens_mixed_exp;
+    if (fcfg.colorscheme == "Greysexp")
+      colorScheme = heatmap_cs_Greys_mixed_exp;
+    if (fcfg.colorscheme == "Orangesexp")
+      colorScheme = heatmap_cs_Oranges_mixed_exp;
+    if (fcfg.colorscheme == "Redsexp") colorScheme = heatmap_cs_Reds_mixed_exp;
+  }
+
+  if (style == RASTER) {
+    if (fcfg.colorscheme == "spectral")
+      colorScheme = heatmap_cs_Spectral_discrete;
+    if (fcfg.colorscheme == "RdYlGn") colorScheme = heatmap_cs_RdYlGn_discrete;
+    if (fcfg.colorscheme == "RdYlBu") colorScheme = heatmap_cs_RdYlBu_discrete;
+    if (fcfg.colorscheme == "RdGy") colorScheme = heatmap_cs_RdGy_discrete;
+    if (fcfg.colorscheme == "YlOrRd") colorScheme = heatmap_cs_YlOrRd_discrete;
+    if (fcfg.colorscheme == "Blues") colorScheme = heatmap_cs_Blues_discrete;
+    if (fcfg.colorscheme == "Greens") colorScheme = heatmap_cs_Greens_discrete;
+    if (fcfg.colorscheme == "Greys") colorScheme = heatmap_cs_Greys_discrete;
+    if (fcfg.colorscheme == "Oranges")
+      colorScheme = heatmap_cs_Oranges_discrete;
+    if (fcfg.colorscheme == "Reds") colorScheme = heatmap_cs_Reds_discrete;
+  }
+
+  if (box.size() != 4) throw std::invalid_argument("Invalid request.");
+
+  LOG(INFO) << "[SERVER] Begin heatmap generation for session " << id;
 
   double x1 = std::atof(box[0].c_str());
   double y1 = std::atof(box[1].c_str());
@@ -300,8 +316,6 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   if (h <= 0 || h > 3000) throw std::invalid_argument("Invalid request");
 
   double res = mercH / h;
-
-  size_t fid = r->getFieldId(field);
 
   checkMem(sizeof(float) * w * h, _maxMemory);
   double realCellSize = r->getPointGrid(fid).getCellWidth();
@@ -674,7 +688,7 @@ util::http::Answer Server::handleGeoJSONReq(const Params& pars,
     throw std::invalid_argument("Session not ready.");
   }
 
-  size_t fid = reqor->getFieldId(layer);
+  size_t fid = reqor->getFieldById(layer);
 
   // as soon as we are ready, the reqor can be read concurrently
   auto res = reqor->getGeom(fid, gid, rad);
@@ -982,46 +996,19 @@ util::http::Answer Server::handleQueryReq(const Params& pars,
 
   RequestorConfig rcfg;
 
-  // backwards compatibility
-  if (pars.count("fields") != 0) {
-    for (auto raw : util::split(pars.find("fields")->second, ';')) {
-      auto parts = util::split(raw, ',');
-      if (parts.size() == 0) continue;
-      rcfg.fields.push_back({
-          parts[0],                          // geomField
-          getFreeLayerId(),                  // id
-          "",                                // name
-          parts.size() > 1 ? parts[1] : "",  // valueField
-                                             // ..., rest defaults
-      });
-    }
-  }
+  const std::string& backend = pars.find("backend")->second;
 
-  if (pars.count("rasterw") != 0 && pars.count("rasterh") != 0) {
-    double rasterW = ::atof(pars.find("rasterw")->second.c_str());
-    double rasterH = ::atof(pars.find("rasterh")->second.c_str());
-
-    // set the same rasterw and rasterh for all fields
-    for (auto& fld : rcfg.fields) {
-      fld.rasterW = rasterW;
-      fld.rasterH = rasterH;
-    }
-  }
+  auto backendCfg = getGeomCacheConfig(backend, "", "", remoteAddr);
 
   if (pars.count("cfg") != 0 && !pars.find("cfg")->second.empty()) {
     rcfg = getRequestorCfgFromJSON(pars.find("cfg")->second);
-  }
-
-  if (pars.count("query") != 0 && !pars.find("query")->second.empty()) {
-    rcfg.query = pars.find("query")->second;
+  } else if (pars.count("query") != 0 && !pars.find("query")->second.empty()) {
+    rcfg =
+        getDefaultRequestorCfg(backendCfg.backend, pars.find("query")->second);
   }
 
   if (rcfg.query.size() == 0)
     throw std::invalid_argument("No query specified.");
-
-  const std::string& backend = pars.find("backend")->second;
-
-  auto backendCfg = getGeomCacheConfig(backend, "", "", remoteAddr);
 
   LOG(INFO) << "[SERVER] Queried backend is " << backendCfg.backend;
   LOG(INFO) << "[SERVER] Query is:\n" << rcfg.query;
@@ -1091,17 +1078,18 @@ util::http::Answer Server::handleQueryReq(const Params& pars,
        << ",\"autothreshold\":" << _autoThreshold << ",\"layers\": [";
 
   bool first = false;
-  for (const auto& fld : reqor->getFields()) {
+  for (size_t fid = 0; fid < reqor->getNumFields(); fid++) {
+    const auto& fld = reqor->getFields()[fid];
     if (first) json << ",";
     first = true;
     json << "{";
     json << "\"id\":\"" << fld.id << "\",";
     json << "\"geomfield\":\"" << fld.geomField << "\",";
     json << "\"name\":\"" << fld.name << "\",";
+    json << "\"group\":\"" << fld.group << "\",";
     json << "\"color\":\"" << fld.color << "\",";
     json << "\"colorscheme\":\"" << fld.colorscheme << "\",";
-    json << "\"numobjects\":\""
-         << reqor->getNumObjects(reqor->getFieldId(fld.geomField)) << "\",";
+    json << "\"numobjects\":\"" << reqor->getNumObjects(fid) << "\",";
     json << "\"style\":\"" << fld.style << "\",";
     json << "\"toggle\":\"" << fld.toggle << "\"";
     if (fld.rasterW != 0 && fld.rasterH != 0)
@@ -1587,6 +1575,8 @@ RequestorConfig Server::getRequestorCfgFromJSON(
             if (layer.value().contains("style"))
               curField.style = layer.value()["style"].get<std::string>();
             if (curField.name.size() == 0) curField.name = curField.geomField;
+
+            // always assign an ID
             if (curField.id.size() == 0) curField.id = getFreeLayerId();
             ret.fields.push_back(curField);
           }
@@ -1680,6 +1670,57 @@ GeomCacheConfig Server::getGeomCacheConfig(
         canonizedBackend, petrimaps::getFillQuery(canonizedBackend)};
   }
   return _cacheConfigs[canonizedBackend];
+}
+
+// _____________________________________________________________________________
+RequestorConfig Server::getDefaultRequestorCfg(const std::string& backend,
+                                               const std::string& query) const {
+  RequestorConfig ret;
+  ret.query = query;
+
+  auto cols = Requestor::getColumns(backend, query);
+  if (cols.size() == 0) return ret;
+
+  const std::vector<std::string> heatmapStyles{
+      "spectralexp", "spectral",   "RdYlGn", "RdYlGnexp", "RdYlBu", "RdYlBuexp",
+      "w2b",         "b2w",        "RdGy",   "RdGyexp",   "YlOrRd", "YlOrRdexp",
+      "Blues",       "Bluesexp",   "Greens", "Greensexp", "Greys",  "Greysexp",
+      "Oranges",     "Orangesexp", "Reds",   "Redsexp"};
+
+  FieldConfig autoField;
+  autoField.geomField = cols.back();
+  autoField.id = "auto";
+  autoField.name = "Auto";
+  autoField.group = "Auto";
+  autoField.color = "3388ff";
+  autoField.style = "auto";
+
+  FieldConfig objectField;
+  autoField.geomField = cols.back();
+  autoField.id = "objects";
+  autoField.name = "Objects";
+  autoField.group = "Objects";
+  autoField.color = "3388ff";
+  autoField.style = "objects";
+
+  ret.fields.push_back(autoField);
+  ret.fields.push_back(objectField);
+
+  size_t i = 0;
+
+  for (const auto& heatmapStyle : heatmapStyles) {
+    i++;
+    if (i > 2) break;
+    FieldConfig heatField;
+    heatField.geomField = cols.back();
+    heatField.group = "Heatmap";
+    heatField.id = std::string("heatmap-") + heatmapStyle;
+    heatField.name = heatmapStyle;
+    heatField.colorscheme = heatmapStyle;
+    ret.fields.push_back(heatField);
+  }
+
+  return ret;
 }
 
 // _____________________________________________________________________________

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -361,8 +361,8 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
           auto px = RenderContext::mercToPx(cp, orx, ory, mercW, mercH, w, h);
           auto ppx = RenderContext::mercToPx(p, orx, ory, mercW, mercH, w, h);
 
-          rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(lid, oid), 0, 0,
-                             1);
+          rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(lid, oid), 0,
+                             0);
           rcontext.drawLineSegment(px.getX(), px.getY(), ppx.getX(), ppx.getY(),
                                    w, h);
         } else {
@@ -377,10 +377,10 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
             auto rasterMeta =
                 r->getRasterMetas(lid, oid, {rasterWidth, rasterHeight});
             rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(lid, oid),
-                               rasterMeta.first, rasterMeta.second, 1);
+                               rasterMeta.first, rasterMeta.second);
           } else {
             rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(lid, oid), 0,
-                               0, 1);
+                               0);
           }
         }
       }
@@ -407,7 +407,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
             // TODO: just setting rasterWidth to 1x1 here is not correct
             rcontext.drawPoint(tid, px.getX(), px.getY(), grid.getCellSum(x, y),
-                               1, 1, 0.5);
+                               1, 1);
           } else {
             for (auto oid : *cell) {
               if (r->isCluster(lid, oid)) oid = r->getCluster(lid, oid).first;
@@ -421,10 +421,10 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
                     r->getRasterMetas(lid, oid, {rasterWidth, rasterHeight});
                 rcontext.drawPoint(tid, px.getX(), px.getY(),
                                    r->getVal(lid, oid), rasterMeta.first,
-                                   rasterMeta.second, 0.5);
+                                   rasterMeta.second);
               } else {
                 rcontext.drawPoint(tid, px.getX(), px.getY(),
-                                   r->getVal(lid, oid), 0, 0, 0.5);
+                                   r->getVal(lid, oid), 0, 0);
               }
             }
           }
@@ -552,49 +552,59 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
         0,         0,
         0,         0,
         objColorR, objColorG,
-        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.06,
+        objColorB, 255 * lcfg.objectStyle.fillOpacity * 0.06,
         objColorR, objColorG,
-        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.12,
+        objColorB, 255 * lcfg.objectStyle.fillOpacity * 0.12,
         objColorR, objColorG,
-        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.25,
+        objColorB, 255 * lcfg.objectStyle.fillOpacity * 0.25,
         objColorR, objColorG,
-        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.5,
+        objColorB, 255 * lcfg.objectStyle.fillOpacity * 0.5,
         objColorR, objColorG,
-        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.65,
+        objColorB, 255 * lcfg.objectStyle.fillOpacity * 0.65,
         objColorR, objColorG,
-        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.8,
+        objColorB, 255 * lcfg.objectStyle.fillOpacity * 0.8,
         objColorR, objColorG,
-        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.9,
+        objColorB, 255 * lcfg.objectStyle.fillOpacity * 0.9,
         objColorR, objColorG,
-        objColorB, 256 * lcfg.objectStyle.fillOpacity};
+        objColorB, 255 * lcfg.objectStyle.fillOpacity};
     heatmap_colorscheme_t fillColorScheme = {
         fillColors, sizeof(fillColors) / sizeof(fillColors[0]) / 4};
 
     unsigned char borderColors2[] = {
-        0,         0,         0,         0,
-        0,         0,         0,         0,
-        objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 255 * lcfg.objectStyle.lineOpacity};
+        0,         0,
+        0,         0,
+        0,         0,
+        0,         0,
+        objColorR, objColorG,
+        objColorB, 0,
+        objColorR, objColorG,
+        objColorB, 0,
+        objColorR, objColorG,
+        objColorB, 0,
+        objColorR, objColorG,
+        objColorB, 0,
+        objColorR, objColorG,
+        objColorB, 0,
+        objColorR, objColorG,
+        objColorB, 0,
+        objColorR, objColorG,
+        objColorB, 0,
+        objColorR, objColorG,
+        objColorB, std::max(1.0, 255 * lcfg.objectStyle.lineOpacity)};
     heatmap_colorscheme_t borderColor2Scheme = {
         borderColors2, sizeof(borderColors2) / sizeof(borderColors2[0]) / 4};
 
     unsigned char borderColors[] = {
         0,         0,         0,         0,
-        objColorR, objColorG, objColorB, 64 * lcfg.objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 64 * lcfg.objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 64 * lcfg.objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 64 * lcfg.objectStyle.lineOpacity,
         objColorR, objColorG, objColorB, 128 * lcfg.objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 160 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 169 * lcfg.objectStyle.lineOpacity,
         objColorR, objColorG, objColorB, 192 * lcfg.objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 192 * lcfg.objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 192 * lcfg.objectStyle.lineOpacity};
+        objColorR, objColorG, objColorB, 255 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 255 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 255 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 255 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 255 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 255 * lcfg.objectStyle.lineOpacity};
     heatmap_colorscheme_t borderColorScheme = {
         borderColors, sizeof(borderColors) / sizeof(borderColors[0]) / 4};
 
@@ -1586,6 +1596,8 @@ RequestorConfig Server::getRequestorCfgFromJSON(
             if (layer.value().contains("pointradius"))
               curField.objectStyle.pointRadius =
                   layer.value()["pointradius"].get<double>();
+            if (layer.value().contains("group"))
+              curField.group = layer.value()["group"].get<std::string>();
             if (curField.name.size() == 0) curField.name = curField.geomField;
 
             // always assign an ID

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -220,10 +220,39 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
     lid = r->getLidById(layerId);
   }
 
+  if (box.size() != 4) throw std::invalid_argument("Invalid request.");
+
+  LOG(INFO) << "[SERVER] Begin heatmap generation for session " << id;
+
+  double x1 = std::atof(box[0].c_str());
+  double y1 = std::atof(box[1].c_str());
+  double x2 = std::atof(box[2].c_str());
+  double y2 = std::atof(box[3].c_str());
+
+  double mercW = fabs(x2 - x1);
+  double mercH = fabs(y2 - y1);
+
+  auto bbox = DBox({x1, y1}, {x2, y2});
+  auto fbbox = FBox({x1, y1}, {x2, y2});
+
+  double orx = bbox.getLowerLeft().getX();
+  double ory = bbox.getLowerLeft().getY();
+
+  int w = atoi(pars.find("width")->second.c_str());
+  int h = atoi(pars.find("height")->second.c_str());
+
+  if (w <= 0 || w > 3000) throw std::invalid_argument("Invalid request");
+  if (h <= 0 || h > 3000) throw std::invalid_argument("Invalid request");
+
+  double res = mercH / h;
+
   lcfg = r->getLayers()[lid];
 
   if (lcfg.style == "objects") style = OBJECTS;
   if (lcfg.style == "raster") style = RASTER;
+  if (lcfg.style == "auto" && res < THRESHOLD &&
+      r->getNumObjects(lid) > _autoThreshold)
+    style = OBJECTS;
 
   if (style == RASTER && parts.size() > 1) {
     // in web mercator units (pseudometers)!
@@ -291,32 +320,6 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
     if (lcfg.colorscheme == "Reds") colorScheme = heatmap_cs_Reds_discrete;
   }
 
-  if (box.size() != 4) throw std::invalid_argument("Invalid request.");
-
-  LOG(INFO) << "[SERVER] Begin heatmap generation for session " << id;
-
-  double x1 = std::atof(box[0].c_str());
-  double y1 = std::atof(box[1].c_str());
-  double x2 = std::atof(box[2].c_str());
-  double y2 = std::atof(box[3].c_str());
-
-  double mercW = fabs(x2 - x1);
-  double mercH = fabs(y2 - y1);
-
-  auto bbox = DBox({x1, y1}, {x2, y2});
-  auto fbbox = FBox({x1, y1}, {x2, y2});
-
-  double orx = bbox.getLowerLeft().getX();
-  double ory = bbox.getLowerLeft().getY();
-
-  int w = atoi(pars.find("width")->second.c_str());
-  int h = atoi(pars.find("height")->second.c_str());
-
-  if (w <= 0 || w > 3000) throw std::invalid_argument("Invalid request");
-  if (h <= 0 || h > 3000) throw std::invalid_argument("Invalid request");
-
-  double res = mercH / h;
-
   checkMem(sizeof(float) * w * h, _maxMemory);
   double realCellSize = r->getPointGrid(lid).getCellWidth();
   double virtCellSize = res * 1.5;
@@ -329,12 +332,10 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   LOG(INFO) << "[SERVER] Virt cell size: " << virtCellSize;
   LOG(INFO) << "[SERVER] Num virt cells: " << subCellSize * subCellSize;
 
-  ObjectStyle objectStyle{3, 2, 0.5, 1};
-
   checkMem(sizeof(unsigned char) * w * h * 4 +
                sizeof(unsigned char) * w * h * 4 * NUM_THREADS * 2,
            _maxMemory);
-  RenderContext rcontext(w, h, orx, ory, mercW, mercH, style, objectStyle,
+  RenderContext rcontext(w, h, orx, ory, mercW, mercH, style, lcfg.objectStyle,
                          NUM_THREADS);
 
   // POINTS
@@ -546,16 +547,26 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
     heatmap_render_to(hm, colorScheme, &rcontext.getImage()[0]);
   } else if (style == OBJECTS) {
     unsigned char fillColors[] = {
-        0,         0,         0,         0,
-        0,         0,         0,         0,
-        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.06,
-        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.12,
-        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.25,
-        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.5,
-        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.65,
-        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.8,
-        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.9,
-        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity};
+        0,         0,
+        0,         0,
+        0,         0,
+        0,         0,
+        objColorR, objColorG,
+        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.06,
+        objColorR, objColorG,
+        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.12,
+        objColorR, objColorG,
+        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.25,
+        objColorR, objColorG,
+        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.5,
+        objColorR, objColorG,
+        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.65,
+        objColorR, objColorG,
+        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.8,
+        objColorR, objColorG,
+        objColorB, 256 * lcfg.objectStyle.fillOpacity * 0.9,
+        objColorR, objColorG,
+        objColorB, 256 * lcfg.objectStyle.fillOpacity};
     heatmap_colorscheme_t fillColorScheme = {
         fillColors, sizeof(fillColors) / sizeof(fillColors[0]) / 4};
 
@@ -569,21 +580,21 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
         objColorR, objColorG, objColorB, 0,
         objColorR, objColorG, objColorB, 0,
         objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 255 * objectStyle.lineOpacity};
+        objColorR, objColorG, objColorB, 255 * lcfg.objectStyle.lineOpacity};
     heatmap_colorscheme_t borderColor2Scheme = {
         borderColors2, sizeof(borderColors2) / sizeof(borderColors2[0]) / 4};
 
     unsigned char borderColors[] = {
         0,         0,         0,         0,
-        objColorR, objColorG, objColorB, 64 * objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 64 * objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 64 * objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 64 * objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 128 * objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 160 * objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 192 * objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 192 * objectStyle.lineOpacity,
-        objColorR, objColorG, objColorB, 192 * objectStyle.lineOpacity};
+        objColorR, objColorG, objColorB, 64 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 64 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 64 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 64 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 128 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 160 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 192 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 192 * lcfg.objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 192 * lcfg.objectStyle.lineOpacity};
     heatmap_colorscheme_t borderColorScheme = {
         borderColors, sizeof(borderColors) / sizeof(borderColors[0]) / 4};
 
@@ -1074,8 +1085,7 @@ util::http::Answer Server::handleQueryReq(const Params& pars,
   std::stringstream json;
   json << std::fixed << "{\"qid\" : \"" << sessionId << "\",\"bounds\":[["
        << llX << "," << llY << "],[" << urX << "," << urY << "]]"
-       << ",\"numobjects\":" << numObjs
-       << ",\"autothreshold\":" << _autoThreshold << ",\"layers\": [";
+       << ",\"numobjects\":" << numObjs << ",\"layers\": [";
 
   bool first = false;
   for (size_t lid = 0; lid < reqor->getNumLayers(); lid++) {
@@ -1564,6 +1574,18 @@ RequestorConfig Server::getRequestorCfgFromJSON(
                   layer.value()["colorscheme"].get<std::string>();
             if (layer.value().contains("style"))
               curField.style = layer.value()["style"].get<std::string>();
+            if (layer.value().contains("linew"))
+              curField.objectStyle.lineWidth =
+                  layer.value()["linew"].get<double>();
+            if (layer.value().contains("fillopacity"))
+              curField.objectStyle.fillOpacity =
+                  layer.value()["fillopacity"].get<double>();
+            if (layer.value().contains("lineopacity"))
+              curField.objectStyle.lineOpacity =
+                  layer.value()["lineopacity"].get<double>();
+            if (layer.value().contains("pointradius"))
+              curField.objectStyle.pointRadius =
+                  layer.value()["pointradius"].get<double>();
             if (curField.name.size() == 0) curField.name = curField.geomField;
 
             // always assign an ID
@@ -1686,12 +1708,12 @@ RequestorConfig Server::getDefaultRequestorCfg(const std::string& backend,
   autoLayer.style = "auto";
 
   LayerConfig objectLayer;
-  autoLayer.geomField = cols.back();
-  autoLayer.id = "objects";
-  autoLayer.name = "Objects";
-  autoLayer.group = "Objects";
-  autoLayer.color = "3388ff";
-  autoLayer.style = "objects";
+  objectLayer.geomField = cols.back();
+  objectLayer.id = "objects";
+  objectLayer.name = "Objects";
+  objectLayer.group = "Objects";
+  objectLayer.color = "3388ff";
+  objectLayer.style = "objects";
 
   ret.layers.push_back(autoLayer);
   ret.layers.push_back(objectLayer);
@@ -1703,6 +1725,7 @@ RequestorConfig Server::getDefaultRequestorCfg(const std::string& backend,
     heatLayer.id = std::string("heatmap-") + heatmapStyle;
     heatLayer.name = heatmapStyle;
     heatLayer.colorscheme = heatmapStyle;
+    heatLayer.style = "heatmap";
     ret.layers.push_back(heatLayer);
   }
 

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -315,10 +315,13 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   LOG(INFO) << "[SERVER] Virt cell size: " << virtCellSize;
   LOG(INFO) << "[SERVER] Num virt cells: " << subCellSize * subCellSize;
 
+  ObjectStyle objectStyle{3, 2, 0.5, 1};
+
   checkMem(sizeof(unsigned char) * w * h * 4 +
                sizeof(unsigned char) * w * h * 4 * NUM_THREADS * 2,
            _maxMemory);
-  RenderContext rcontext(w, h, orx, ory, mercW, mercH, style, NUM_THREADS);
+  RenderContext rcontext(w, h, orx, ory, mercW, mercH, style, objectStyle,
+                         NUM_THREADS);
 
   // POINTS
   if (intersects(r->getPointGrid(fid).getBBox(), fbbox)) {
@@ -389,7 +392,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
             // TODO: just setting rasterWidth to 1x1 here is not correct
             rcontext.drawPoint(tid, px.getX(), px.getY(), grid.getCellSum(x, y),
-                               1, 1, 1);
+                               1, 1, 0.5);
           } else {
             for (auto oid : *cell) {
               if (r->isCluster(fid, oid)) oid = r->getCluster(fid, oid).first;
@@ -403,10 +406,10 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
                     r->getRasterMetas(fid, oid, {rasterWidth, rasterHeight});
                 rcontext.drawPoint(tid, px.getX(), px.getY(),
                                    r->getVal(fid, oid), rasterMeta.first,
-                                   rasterMeta.second, 1);
+                                   rasterMeta.second, 0.5);
               } else {
                 rcontext.drawPoint(tid, px.getX(), px.getY(),
-                                   r->getVal(fid, oid), 0, 0, 1);
+                                   r->getVal(fid, oid), 0, 0, 0.5);
               }
             }
           }
@@ -470,9 +473,9 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
           if (subCellSize == 1) {
             auto pix = RenderContext::mercToPx(cellBox.getLowerLeft(), orx, ory,
                                                mercW, mercH, w, h);
-            rcontext.drawPoint(tid, pix.getX(), pix.getY(),
-                               lpgrid.getCellSum(x, y), rasterWidth,
-                               rasterHeight, 0);
+            rcontext.drawLinePoint(tid, pix.getX(), pix.getY(),
+                                   lpgrid.getCellSum(x, y), rasterWidth,
+                                   rasterHeight);
           } else {
             for (const auto& p : *cell) {
               int px = ((cellBox.getLowerLeft().getX() + p.getX() * 256 -
@@ -483,7 +486,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
                              bbox.getLowerLeft().getY()) /
                             mercH) *
                                h;
-              rcontext.drawPoint(tid, px, py, 1, rasterWidth, rasterHeight, 0);
+              rcontext.drawLinePoint(tid, px, py, 1, rasterWidth, rasterHeight);
             }
           }
         }
@@ -529,36 +532,44 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
     heatmap_render_to(hm, colorScheme, &rcontext.getImage()[0]);
   } else if (style == OBJECTS) {
     unsigned char fillColors[] = {
-        0,         0,         0,         0,         0,         0,
-        0,         0,         objColorR, objColorG, objColorB, 8,
-        objColorR, objColorG, objColorB, 16,        objColorR, objColorG,
-        objColorB, 32,        objColorR, objColorG, objColorB, 64,
-        objColorR, objColorG, objColorB, 80,        objColorR, objColorG,
-        objColorB, 96,        objColorR, objColorG, objColorB, 112,
-        objColorR, objColorG, objColorB, 127};
+        0,         0,         0,         0,
+        0,         0,         0,         0,
+        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.06,
+        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.12,
+        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.25,
+        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.5,
+        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.65,
+        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.8,
+        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity * 0.9,
+        objColorR, objColorG, objColorB, 256 * objectStyle.fillOpacity};
     heatmap_colorscheme_t fillColorScheme = {
         fillColors, sizeof(fillColors) / sizeof(fillColors[0]) / 4};
 
     unsigned char borderColors2[] = {
-        0,         0,         0,         0,         0,         0,
-        0,         0,         objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 0,         objColorR, objColorG,
-        objColorB, 0,         objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 0,         objColorR, objColorG,
-        objColorB, 0,         objColorR, objColorG, objColorB, 0,
-        objColorR, objColorG, objColorB, 255};
+        0,         0,         0,         0,
+        0,         0,         0,         0,
+        objColorR, objColorG, objColorB, 0,
+        objColorR, objColorG, objColorB, 0,
+        objColorR, objColorG, objColorB, 0,
+        objColorR, objColorG, objColorB, 0,
+        objColorR, objColorG, objColorB, 0,
+        objColorR, objColorG, objColorB, 0,
+        objColorR, objColorG, objColorB, 0,
+        objColorR, objColorG, objColorB, 255 * objectStyle.lineOpacity};
     heatmap_colorscheme_t borderColor2Scheme = {
         borderColors2, sizeof(borderColors2) / sizeof(borderColors2[0]) / 4};
 
     unsigned char borderColors[] = {
-        0, 0,
-        0, 0,         objColorR, objColorG,
-        objColorB, 64,        objColorR, objColorG, objColorB, 64,
-        objColorR, objColorG, objColorB, 64,        objColorR, objColorG,
-        objColorB, 64,        objColorR, objColorG, objColorB, 128,
-        objColorR, objColorG, objColorB, 160,       objColorR, objColorG,
-        objColorB, 192,       objColorR, objColorG, objColorB, 192,
-        objColorR, objColorG, objColorB, 192};
+        0,         0,         0,         0,
+        objColorR, objColorG, objColorB, 64 * objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 64 * objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 64 * objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 64 * objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 128 * objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 160 * objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 192 * objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 192 * objectStyle.lineOpacity,
+        objColorR, objColorG, objColorB, 192 * objectStyle.lineOpacity};
     heatmap_colorscheme_t borderColorScheme = {
         borderColors, sizeof(borderColors) / sizeof(borderColors[0]) / 4};
 

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -6,6 +6,7 @@
 #include <sys/socket.h>
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <codecvt>
 #include <csignal>
@@ -65,11 +66,68 @@ using util::geo::DPoint;
 using util::geo::extendBox;
 using util::geo::intersection;
 using util::geo::intersects;
+using util::geo::latLngToWebMerc;
 using util::geo::LineSegment;
 using util::geo::webMercToLatLng;
 
 const static double THRESHOLD = 200;
 static std::atomic<size_t> _curRow;
+
+// _____________________________________________________________________________
+static void sendRaw(int sock, const std::string& buff) {
+  // write buff to sock, blocking until everything has been written
+  size_t writes = 0;
+
+  while (writes != buff.size()) {
+    int64_t out =
+        send(sock, buff.c_str() + writes, buff.size() - writes, MSG_NOSIGNAL);
+    if (out < 0) {
+      if (errno == EWOULDBLOCK || errno == EAGAIN || errno == EINTR) continue;
+      throw std::runtime_error("Failed to write to socket");
+    }
+    writes += out;
+  }
+}
+
+// _____________________________________________________________________________
+static bool printWKTFeature(std::stringstream& ss, const std::string& wkt,
+                            const util::json::Val& dict, bool hadFeature) {
+  const char* s = wkt.c_str();
+
+  if (*s == '"') s++;  // drop " at beginning
+
+  auto wktType = util::geo::getWKTType(s, &s);
+
+  if (wktType == util::geo::WKTType::NONE) return hadFeature;
+
+  if (hadFeature) ss << ",";
+
+  GeoJsonOutput geoJsonOut(ss, true);
+
+  if (wktType == util::geo::WKTType::POLYGON) {
+    geoJsonOut.print(util::geo::polygonFromWKT<double>(s, 0), dict);
+  }
+  if (wktType == util::geo::WKTType::MULTIPOLYGON) {
+    geoJsonOut.print(util::geo::multiPolygonFromWKT<double>(s, 0), dict);
+  }
+  if (wktType == util::geo::WKTType::POINT) {
+    geoJsonOut.print(util::geo::pointFromWKT<double>(s, 0), dict);
+  }
+  if (wktType == util::geo::WKTType::MULTIPOINT) {
+    geoJsonOut.print(util::geo::multiPointFromWKT<double>(s, 0), dict);
+  }
+  if (wktType == util::geo::WKTType::LINESTRING) {
+    geoJsonOut.print(util::geo::lineFromWKT<double>(s, 0), dict);
+  }
+  if (wktType == util::geo::WKTType::MULTILINESTRING) {
+    geoJsonOut.print(util::geo::multiLineFromWKT<double>(s, 0), dict);
+  }
+  if (wktType == util::geo::WKTType::COLLECTION) {
+    geoJsonOut.print(util::geo::collectionFromWKT<double>(s, 0), dict);
+  }
+
+  return true;
+}
 
 // _____________________________________________________________________________
 Server::Server(size_t maxMemory, const std::string& cacheDir, int cacheLifetime,
@@ -105,9 +163,6 @@ util::http::Answer Server::handle(const util::http::Req& req, int con) const {
     } else if (cmd == "/query") {
       LOG(INFO) << "Query request from " << remoteAddress(con, req.params);
       a = handleQueryReq(params, req.params, con);
-    } else if (cmd == "/geojson") {
-      LOG(INFO) << "Geojson request from " << remoteAddress(con, req.params);
-      a = handleGeoJSONReq(params, req.params, con);
     } else if (cmd == "/clearsession") {
       a = handleClearSessReq(params, req.params, con);
     } else if (cmd == "/clearsessions") {
@@ -115,9 +170,6 @@ util::http::Answer Server::handle(const util::http::Req& req, int con) const {
     } else if (cmd == "/pos") {
       LOG(INFO) << "Position request from " << remoteAddress(con, req.params);
       a = handlePosReq(params, req.params, con);
-    } else if (cmd == "/export") {
-      LOG(INFO) << "Export request from " << remoteAddress(con, req.params);
-      a = handleExportReq(params, req.params, con);
     } else if (cmd == "/loadstatus") {
       a = handleLoadStatusReq(params, req.params, con);
     } else if (cmd == "/build.js") {
@@ -135,6 +187,53 @@ util::http::Answer Server::handle(const util::http::Req& req, int con) const {
       a.params["Cache-Control"] = "public, max-age=10000";
     } else if (cmd == "/heatmap") {
       a = handleHeatMapReq(params, con);
+    } else if (cmd.find("/tms/") == 0) {
+      std::string tmsPath = cmd.substr(5);
+      auto parts = util::split(tmsPath, '/');
+
+      if (parts.size() != 5) {
+        throw std::invalid_argument("Invalid TMS request.");
+      }
+      if (parts[4].size() < 5 ||
+          parts[4].substr(parts[4].size() - 4) != ".png") {
+        throw std::invalid_argument("Invalid TMS request.");
+      }
+
+      params["layers"] = parts[0];
+      params["styles"] = parts[1];
+      params["x"] = parts[2];
+      params["y"] = parts[3];
+      params["z"] = parts[4].substr(0, parts[4].size() - 4);
+
+      a = handleTMSReq(params, con);
+    } else if (cmd == "/wmts") {
+      a = handleWMTSReq(params, con);
+    } else if (cmd == "/wfs") {
+      a = handleWFSReq(params, req.params, con);
+    } else if (cmd.find("/wmts/") == 0) {
+      std::string wmtsPath = cmd.substr(6);
+      auto parts = util::split(wmtsPath, '/');
+
+      if (parts.size() != 6) {
+        throw std::invalid_argument("Invalid RESTful WMTS request.");
+      }
+      if (parts[5].size() < 5 ||
+          parts[5].substr(parts[5].size() - 4) != ".png") {
+        throw std::invalid_argument("Invalid RESTful WMTS request.");
+      }
+
+      params["service"] = "wmts";
+      params["request"] = "gettile";
+      params["version"] = "1.0.0";
+      params["layer"] = parts[0];
+      params["style"] = parts[1];
+      params["format"] = "image/png";
+      params["tilematrixset"] = parts[2];
+      params["tilematrix"] = parts[3];
+      params["tilerow"] = parts[4];
+      params["tilecol"] = parts[5].substr(0, parts[5].size() - 4);
+
+      a = handleWMTSGetTileReq(params, con);
     } else {
       a = util::http::Answer("404 Not Found", "dunno");
     }
@@ -528,7 +627,6 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
       }
     }
   }
-
   LOG(INFO) << "[SERVER] Adding points to heatmap...";
   heatmap_t* hm = heatmap_new(w, h);
   heatmap_t* hmInterior = heatmap_new(w, h);
@@ -619,7 +717,6 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   } else {
     heatmap_render_to(hm, colorScheme, &rcontext.getImage()[0]);
   }
-
   heatmap_free(hm);
   heatmap_free(hmInterior);
 
@@ -638,7 +735,9 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
   // point 7
 
   std::stringstream ss;
+
   ss << "HTTP/1.1 " << aw.status << "\r\n";
+
   for (const auto& kv : aw.params)
     ss << kv.first << ": " << kv.second << "\r\n";
 
@@ -664,112 +763,1136 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
   return aw;
 }
+std::string lower(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return s;
+}
+
+const std::string* getParamCaseInsensitive(const Params& pars,
+                                           const std::string& key) {
+  for (const auto& entry : pars) {
+    if (lower(entry.first) == key) {
+      return &entry.second;
+    }
+  }
+  return nullptr;
+}
+// _____________________________________________________________________________
+util::http::Answer Server::handleWMTSReq(const Params& pars, int sock) const {
+  const std::string* requestParam = getParamCaseInsensitive(pars, "request");
+  if (requestParam == nullptr || requestParam->empty()) {
+    throw std::invalid_argument("No WMTS request specified.");
+  }
+
+  std::string request = lower(*requestParam);
+
+  if (request == "gettile") {
+    return handleWMTSGetTileReq(pars, sock);
+  }
+
+  if (request == "getcapabilities") {
+    return handleWMTSGetCapabilitiesReq(pars);
+  }
+
+  throw std::invalid_argument("Unsupported WMTS request.");
+}
+// _____________________________________________________________________________
+util::http::Answer Server::handleWFSReq(const Params& pars,
+                                        const HeaderParams& headerPars,
+                                        int sock) const {
+  const std::string* requestParam = getParamCaseInsensitive(pars, "request");
+  if (requestParam == nullptr || requestParam->empty()) {
+    throw std::invalid_argument("No WFS request specified.");
+  }
+
+  std::string request = lower(*requestParam);
+
+  if (request == "getcapabilities") {
+    return handleWFSGetCapabilitiesReq(pars);
+  }
+
+  if (request == "getfeature") {
+    return handleWFSGetFeatureReq(pars, headerPars, sock);
+  }
+
+  if (request == "describefeaturetype") {
+    return handleWFSDescribeFeatureTypeReq(pars);
+  }
+
+  throw std::invalid_argument("Unsupported WFS request.");
+}
+// _____________________________________________________________________________
+util::http::Answer Server::handleWMTSGetTileReq(const Params& pars,
+                                                int sock) const {
+  UNUSED(sock);
+
+  const std::string* serviceParam = getParamCaseInsensitive(pars, "service");
+  if (serviceParam == nullptr || serviceParam->empty()) {
+    throw std::invalid_argument("No WMTS service specified.");
+  }
+
+  if (lower(*serviceParam) != "wmts") {
+    throw std::invalid_argument("Invalid WMTS service.");
+  }
+
+  const std::string* versionParam = getParamCaseInsensitive(pars, "version");
+  if (versionParam == nullptr || versionParam->empty()) {
+    throw std::invalid_argument("No WMTS version specified.");
+  }
+
+  if (*versionParam != "1.0.0") {
+    throw std::invalid_argument("Unsupported WMTS version.");
+  }
+
+  const std::string* layerParam = getParamCaseInsensitive(pars, "layer");
+  if (layerParam == nullptr || layerParam->empty()) {
+    throw std::invalid_argument("No WMTS layer specified.");
+  }
+
+  const std::string* styleParam = getParamCaseInsensitive(pars, "style");
+  if (styleParam == nullptr || styleParam->empty()) {
+    throw std::invalid_argument("No WMTS style specified.");
+  }
+
+  const std::string* formatParam = getParamCaseInsensitive(pars, "format");
+  if (formatParam == nullptr || formatParam->empty()) {
+    throw std::invalid_argument("No WMTS format specified.");
+  }
+
+  if (lower(*formatParam) != "image/png") {
+    throw std::invalid_argument("Unsupported WMTS format.");
+  }
+
+  const std::string* tileMatrixSetParam =
+      getParamCaseInsensitive(pars, "tilematrixset");
+  if (tileMatrixSetParam == nullptr || tileMatrixSetParam->empty()) {
+    throw std::invalid_argument("No WMTS TileMatrixSet specified.");
+  }
+
+  if (lower(*tileMatrixSetParam) != "webmercatorquad") {
+    throw std::invalid_argument("Unsupported WMTS TileMatrixSet.");
+  }
+
+  const std::string* tileMatrixParam =
+      getParamCaseInsensitive(pars, "tilematrix");
+  if (tileMatrixParam == nullptr || tileMatrixParam->empty()) {
+    throw std::invalid_argument("No WMTS TileMatrix specified.");
+  }
+
+  const std::string* tileRowParam = getParamCaseInsensitive(pars, "tilerow");
+  if (tileRowParam == nullptr || tileRowParam->empty()) {
+    throw std::invalid_argument("No WMTS TileRow specified.");
+  }
+
+  const std::string* tileColParam = getParamCaseInsensitive(pars, "tilecol");
+  if (tileColParam == nullptr || tileColParam->empty()) {
+    throw std::invalid_argument("No WMTS TileCol specified.");
+  }
+
+  std::string id = *layerParam;
+  std::string styleStr = *styleParam;
+  std::string heatLayer = getHeatLayer(id);
+
+  int x = atoi(tileColParam->c_str());
+  int y = atoi(tileRowParam->c_str());
+  int z = atoi(tileMatrixParam->c_str());
+
+  std::string bbox = getWebMercatorTileBbox(x, y, z);
+
+  Params heatPars = pars;
+  heatPars["layers"] = heatLayer;
+  heatPars["styles"] = styleStr;
+  heatPars["bbox"] = bbox;
+  heatPars["width"] = "256";
+  heatPars["height"] = "256";
+
+  // tmp: log request parameters
+  LOG(INFO) << "[SERVER] WMTS GetTile request: layer=" << id
+            << " style=" << styleStr << " tileMatrix=" << z << " tileRow=" << y
+            << " tileCol=" << x;
+  LOG(INFO) << " bbox=" << bbox;
+
+  return handleHeatMapReq(heatPars, sock);
+}
 
 // _____________________________________________________________________________
-util::http::Answer Server::handleGeoJSONReq(const Params& pars,
-                                            const HeaderParams& headers,
-                                            int sock) const {
-  auto remoteAddr = remoteAddress(sock, headers);
+util::http::Answer Server::handleWMTSGetCapabilitiesReq(
+    const Params& pars) const {
+  const std::string* serviceParam = getParamCaseInsensitive(pars, "service");
+  if (serviceParam == nullptr || serviceParam->empty()) {
+    throw std::invalid_argument("No WMTS service specified.");
+  }
 
-  if (pars.count("id") == 0 || pars.find("id")->second.empty())
-    throw std::invalid_argument("No session id (?id=) specified.");
-  auto id = pars.find("id")->second;
+  if (lower(*serviceParam) != "wmts") {
+    throw std::invalid_argument("Invalid WMTS service.");
+  }
 
-  if (pars.count("rad") == 0 || pars.find("rad")->second.empty())
-    throw std::invalid_argument("No rad (?rad=) specified.");
-  auto rad = std::atof(pars.find("rad")->second.c_str());
+  const std::string* versionParam = getParamCaseInsensitive(pars, "version");
+  if (versionParam == nullptr || versionParam->empty()) {
+    throw std::invalid_argument("No WMTS version specified.");
+  }
 
-  if (pars.count("gid") == 0 || pars.find("gid")->second.empty())
-    throw std::invalid_argument("No geom id (?gid=) specified.");
-  size_t gid = std::atoi(pars.find("gid")->second.c_str());
+  if (*versionParam != "1.0.0") {
+    throw std::invalid_argument("Unsupported WMTS version.");
+  }
 
-  if (pars.count("layer") == 0 || pars.find("layer")->second.empty())
-    throw std::invalid_argument("No layer (?layer=) specified.");
-  std::string layer = pars.find("layer")->second.c_str();
+  const double WEBMERC_MAX = 20037508.342789244;
+  const double WEBMERC_MIN = -20037508.342789244;
+  const double INITIAL_RESOLUTION = (WEBMERC_MAX - WEBMERC_MIN) / 256.0;
+  const int MAX_ZOOM = 30;
 
-  bool noExport = pars.count("export") == 0 ||
-                  pars.find("export")->second.empty() ||
-                  !std::atoi(pars.find("export")->second.c_str());
+  auto formatStyleNumber = [](double value) {
+    std::ostringstream out;
+    out << value;
+    return out.str();
+  };
 
-  LOG(INFO) << "[SERVER] GeoJSON request for " << gid;
+  std::vector<std::pair<std::string, std::vector<std::string>>> wmtsLayers;
+  {
+    std::lock_guard<std::mutex> guard(_m);
 
-  std::shared_ptr<Requestor> reqor;
+    for (const auto& entry : _rs) {
+      const std::string& sessionId = entry.first;
+      const auto& reqor = entry.second;
+
+      const auto layers = reqor->getLayers();
+      for (const auto& layer : layers) {
+        std::string layerId = sessionId + "-" + layer.id;
+        std::vector<std::string> styles;
+
+        if (layer.style == "heatmap") {
+          styles.push_back("heatmap-" + layer.colorscheme);
+        } else if (layer.style == "objects") {
+          styles.push_back("objects-" + layer.color);
+        } else if (layer.style == "raster") {
+          styles.push_back("raster-" + formatStyleNumber(layer.rasterW) + "x" +
+                           formatStyleNumber(layer.rasterH) + "-" +
+                           layer.colorscheme);
+        } else if (layer.style == "auto") {
+          styles.push_back("heatmap-" + layer.colorscheme);
+          styles.push_back("objects-" + layer.color);
+        } else {
+          styles.push_back("heatmap-" + layer.colorscheme);
+        }
+
+        wmtsLayers.emplace_back(layerId, styles);
+      }
+    }
+  }
+
+  LOG(INFO) << "[SERVER] WMTS GetCapabilities with " << wmtsLayers.size()
+            << " layers.";
+
+  std::stringstream xml;
+
+  xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+  xml << "<Capabilities "
+      << "xmlns=\"http://www.opengis.net/wmts/1.0\" "
+      << "xmlns:ows=\"http://www.opengis.net/ows/1.1\" "
+      << "xmlns:xlink=\"http://www.w3.org/1999/xlink\" "
+      << "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+      << "version=\"1.0.0\">\n ";
+
+  xml << "  <ows:ServiceIdentification>\n"
+      << "    <ows:Title>qlever-petrimaps WMTS Service</ows:Title>\n"
+      << "    <ows:Abstract>WMTS service for qlever-petrimaps</ows:Abstract>\n"
+      << "    <ows:ServiceType>OGC WMTS</ows:ServiceType>\n"
+      << "    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>\n"
+      << "  </ows:ServiceIdentification>\n";
+
+  xml << "  <ows:OperationsMetadata>\n";
+  xml << "    <ows:Operation name=\"GetCapabilities\">\n";
+  xml << "      <ows:DCP>\n";
+  xml << "        <ows:HTTP>\n";
+  xml << "          <ows:Get xlink:href=\"/wmts\" />\n";
+  xml << "        </ows:HTTP>\n";
+  xml << "      </ows:DCP>\n";
+  xml << "    </ows:Operation>\n";
+  xml << "    <ows:Operation name=\"GetTile\">\n";
+  xml << "      <ows:DCP>\n";
+  xml << "        <ows:HTTP>\n";
+  xml << "          <ows:Get xlink:href=\"/wmts\" />\n";
+  xml << "        </ows:HTTP>\n";
+  xml << "      </ows:DCP>\n";
+  xml << "    </ows:Operation>\n";
+  xml << "  </ows:OperationsMetadata>\n";
+
+  xml << "  <Contents>\n";
+
+  for (const auto& layerEntry : wmtsLayers) {
+    const auto& layerId = layerEntry.first;
+    const auto& styles = layerEntry.second;
+
+    std::string escapedLayerId = xmlEscape(layerId);
+    std::string encodedLayerId = xmlEscape(urlEncode(layerId));
+
+    xml << "    <Layer>\n";
+    xml << "      <ows:Title>" << escapedLayerId << "</ows:Title>\n";
+    xml << "      <ows:Identifier>" << encodedLayerId << "</ows:Identifier>\n";
+    for (size_t i = 0; i < styles.size(); i++) {
+      std::string encodedStyle = xmlEscape(urlEncode(styles[i]));
+      xml << "      <Style isDefault=\"" << (i == 0 ? "true" : "false")
+          << "\">\n";
+      xml << "        <ows:Identifier>" << encodedStyle
+          << "</ows:Identifier>\n";
+      xml << "      </Style>\n";
+    }
+    xml << "      <Format>image/png</Format>\n";
+    xml << "      <TileMatrixSetLink>\n";
+    xml << "        <TileMatrixSet>WebMercatorQuad</TileMatrixSet>\n";
+    xml << "      </TileMatrixSetLink>\n";
+
+    xml << "      <ResourceURL format=\"image/png\" resourceType=\"tile\" "
+        << "template=\"/wmts?service=wmts&amp;request=GetTile&amp;version=1.0.0"
+        << "&amp;layer=" << encodedLayerId << "&amp;style={Style}"
+        << "&amp;format=image/png"
+        << "&amp;tilematrixset=WebMercatorQuad"
+        << "&amp;tilematrix={TileMatrix}"
+        << "&amp;tilerow={TileRow}"
+        << "&amp;tilecol={TileCol}\" />\n";
+    xml << "    </Layer>\n";
+  }
+
+  xml << "    <TileMatrixSet>\n";
+  xml << "      <ows:Identifier>WebMercatorQuad</ows:Identifier>\n";
+  xml << "      "
+         "<ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>\n";
+
+  for (int z = 0; z <= MAX_ZOOM; z++) {
+    uint64_t matrixSize = 1ULL << z;
+    double resolution = INITIAL_RESOLUTION / static_cast<double>(matrixSize);
+    double scaleDenominator = resolution / 0.00028;
+    // 0.28 mm pixel size as per OGC standard
+
+    xml << "      <TileMatrix>\n";
+    xml << "        <ows:Identifier>" << z << "</ows:Identifier>\n";
+    xml << "        <ScaleDenominator>" << std::setprecision(15)
+        << scaleDenominator << "</ScaleDenominator>\n";
+    xml << "        <TopLeftCorner>" << WEBMERC_MIN << " " << WEBMERC_MAX
+        << "</TopLeftCorner>\n";
+    xml << "        <TileWidth>256</TileWidth>\n";
+    xml << "        <TileHeight>256</TileHeight>\n";
+    xml << "        <MatrixWidth>" << matrixSize << "</MatrixWidth>\n";
+    xml << "        <MatrixHeight>" << matrixSize << "</MatrixHeight>\n";
+    xml << "      </TileMatrix>\n";
+  }
+
+  xml << "    </TileMatrixSet>\n";
+  xml << "  </Contents>\n";
+
+  xml << "</Capabilities>\n";
+
+  util::http::Answer answ("200 OK", xml.str());
+  answ.params["Content-Type"] = "application/xml; charset=UTF-8";
+  answ.params["Cache-Control"] = "no-cache";
+
+  return answ;
+}
+
+// _____________________________________________________________________________
+util::http::Answer Server::handleWFSGetCapabilitiesReq(
+    const Params& pars) const {
+  const std::string* serviceParam = getParamCaseInsensitive(pars, "service");
+  if (serviceParam == nullptr || serviceParam->empty()) {
+    throw std::invalid_argument("No WFS service specified.");
+  }
+
+  if (lower(*serviceParam) != "wfs") {
+    throw std::invalid_argument("Invalid WFS service.");
+  }
+  const std::string* versionParam = getParamCaseInsensitive(pars, "version");
+  if (versionParam == nullptr || versionParam->empty()) {
+    throw std::invalid_argument("No WFS version specified.");
+  }
+
+  if (lower(*versionParam) != "2.0.0") {
+    throw std::invalid_argument("Unsupported WFS version.");
+  }
+
+  std::vector<std::string> wfsTypeNames;
+  {
+    std::lock_guard<std::mutex> guard(_m);
+
+    for (const auto& entry : _rs) {
+      const std::string& sessionId = entry.first;
+      wfsTypeNames.push_back("session_" + sessionId);
+    }
+  }
+
+  LOG(INFO) << "[SERVER] WFS GetCapabilities with " << wfsTypeNames.size()
+            << " layers.";
+
+  std::stringstream xml;
+
+  xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+  xml << "<WFS_Capabilities "
+      << "xmlns=\"http://www.opengis.net/wfs/2.0\" "
+      << "xmlns:wfs=\"http://www.opengis.net/wfs/2.0\" "
+      << "xmlns:ows=\"http://www.opengis.net/ows/1.1\" "
+      << "xmlns:xlink=\"http://www.w3.org/1999/xlink\" "
+      << "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+      << "version=\"2.0.0\">\n";
+
+  xml << "  <ows:ServiceIdentification>\n"
+      << "    <ows:Title>qlever-petrimaps WFS Service</ows:Title>\n"
+      << "    <ows:Abstract>WFS service for qlever-petrimaps</ows:Abstract>\n"
+      << "    <ows:ServiceType>WFS</ows:ServiceType>\n"
+      << "    <ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>\n"
+      << "  </ows:ServiceIdentification>\n";
+
+  xml << "  <ows:OperationsMetadata>\n";
+  xml << "    <ows:Operation name=\"GetCapabilities\">\n";
+  xml << "      <ows:DCP>\n";
+  xml << "        <ows:HTTP>\n";
+  xml << "          <ows:Get xlink:href=\"/wfs\" />\n";
+  xml << "        </ows:HTTP>\n";
+  xml << "      </ows:DCP>\n";
+  xml << "    </ows:Operation>\n";
+  xml << "    <ows:Operation name=\"DescribeFeatureType\">\n";
+  xml << "      <ows:DCP>\n";
+  xml << "        <ows:HTTP>\n";
+  xml << "          <ows:Get xlink:href=\"/wfs\" />\n";
+  xml << "        </ows:HTTP>\n";
+  xml << "      </ows:DCP>\n";
+  xml << "      <ows:Parameter name=\"outputFormat\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:Value>text/xml; subtype=gml/3.2</ows:Value>\n";
+  xml << "          <ows:Value>application/gml+xml; version=3.2</ows:Value>\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "       </ows:Parameter>\n";
+  xml << "      </ows:Operation>\n";
+  xml << "    <ows:Operation name=\"GetFeature\">\n";
+  xml << "      <ows:DCP>\n";
+  xml << "        <ows:HTTP>\n";
+  xml << "          <ows:Get xlink:href=\"/wfs\" />\n";
+  xml << "        </ows:HTTP>\n";
+  xml << "      </ows:DCP>\n";
+  xml << "      <ows:Parameter name=\"outputFormat\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:Value>application/json</ows:Value>\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"count\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:AnyValue />\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"startindex\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:AnyValue />\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"bbox\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:AnyValue />\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"srsName\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:Value>EPSG:4326</ows:Value>\n";
+  xml << "          <ows:Value>urn:ogc:def:crs:EPSG::4326</ows:Value>\n";
+  xml << "          <ows:Value>EPSG:3857</ows:Value>\n";
+  xml << "          <ows:Value>urn:ogc:def:crs:EPSG::3857</ows:Value>\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"id\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:AnyValue />\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"x\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:AnyValue />\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"y\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:AnyValue />\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"rad\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:AnyValue />\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"width\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:AnyValue />\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "      <ows:Parameter name=\"height\">\n";
+  xml << "        <ows:AllowedValues>\n";
+  xml << "          <ows:AnyValue />\n";
+  xml << "        </ows:AllowedValues>\n";
+  xml << "      </ows:Parameter>\n";
+  xml << "    </ows:Operation>\n";
+  xml << "  </ows:OperationsMetadata>\n";
+
+  xml << "  <FeatureTypeList>\n";
+  for (const auto& typeName : wfsTypeNames) {
+    std::string escapedTypeName = xmlEscape(typeName);
+
+    xml << "    <FeatureType>\n";
+    xml << "      <Name>" << escapedTypeName << "</Name>\n";
+    xml << "      <Title>" << escapedTypeName << "</Title>\n";
+    xml << "      <DefaultCRS>urn:ogc:def:crs:EPSG::4326</DefaultCRS>\n";
+    xml << "      <OtherCRS>urn:ogc:def:crs:EPSG::3857</OtherCRS>\n";
+    xml << "      <OutputFormats>\n";
+    xml << "        <Format>application/json</Format>\n";
+    xml << "      </OutputFormats>\n";
+    xml << "    </FeatureType>\n";
+  }
+  xml << "  </FeatureTypeList>\n";
+
+  xml << "</WFS_Capabilities>\n";
+
+  util::http::Answer answ("200 OK", xml.str());
+  answ.params["Content-Type"] = "application/xml; charset=UTF-8";
+  answ.params["Cache-Control"] = "no-cache";
+
+  return answ;
+}
+
+// _____________________________________________________________________________
+util::http::Answer Server::handleWFSDescribeFeatureTypeReq(
+    const Params& pars) const {
+  const std::string* serviceParam = getParamCaseInsensitive(pars, "service");
+  if (serviceParam == nullptr || serviceParam->empty()) {
+    throw std::invalid_argument("No WFS service specified.");
+  }
+
+  if (lower(*serviceParam) != "wfs") {
+    throw std::invalid_argument("Invalid WFS service.");
+  }
+
+  const std::string* versionParam = getParamCaseInsensitive(pars, "version");
+  if (versionParam == nullptr || versionParam->empty()) {
+    throw std::invalid_argument("No WFS version specified.");
+  }
+
+  if (lower(*versionParam) != "2.0.0") {
+    throw std::invalid_argument("Unsupported WFS version.");
+  }
+
+  std::string typeName;
+  const std::string* typeNamesParam =
+      getParamCaseInsensitive(pars, "typenames");
+  const std::string* typeNameParam = getParamCaseInsensitive(pars, "typename");
+
+  if (typeNamesParam != nullptr && !typeNamesParam->empty()) {
+    typeName = *typeNamesParam;
+  } else if (typeNameParam != nullptr && !typeNameParam->empty()) {
+    typeName = *typeNameParam;
+  } else {
+    throw std::invalid_argument("No WFS typename specified.");
+  }
+
+  std::string sessionId = typeName;
+  const std::string prefix = "session_";
+  if (sessionId.rfind(prefix, 0) == 0) {
+    sessionId = sessionId.substr(prefix.size());
+  }
 
   {
     std::lock_guard<std::mutex> guard(_m);
-    bool has = _rs.count(id);
-    if (!has) {
-      LOG(ERROR) << "Session " << id << " not found!";
-      throw std::invalid_argument("Session not found");
+    if (!_rs.count(typeName)) {
+      throw std::invalid_argument("WFS type name not found.");
     }
-    reqor = _rs[id];
+  }
+  std::string schemaTypeName = "session_" + sessionId;
+  std::string escapedTypeName = xmlEscape(schemaTypeName);
+
+  std::stringstream xml;
+  xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+  xml << "<xsd:schema "
+      << "xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" "
+      << "xmlns:gml=\"http://www.opengis.net/gml/3.2\" "
+      << "xmlns:qpm=\"https://qlever.dev/qlever-petrimaps/wfs\" "
+      << "targetNamespace=\"https://qlever.dev/qlever-petrimaps/wfs\" "
+      << "elementFormDefault=\"qualified\" "
+      << "version=\"2.0.0\">\n";
+  xml << "  <xsd:import namespace=\"http://www.opengis.net/gml/3.2\" />\n";
+  xml << "  <xsd:complexType name=\"ObjectType\">\n";
+  xml << "    <xsd:complexContent>\n";
+  xml << "      <xsd:extension base=\"gml:AbstractFeatureType\">\n";
+  xml << "        <xsd:sequence>\n";
+  xml << "          <xsd:element name=\"geometry\" "
+      << "type=\"gml:GeometryPropertyType\" minOccurs=\"0\" />\n";
+  xml << "          <xsd:element name=\"gid\" "
+      << "type=\"xsd:unsignedLong\" minOccurs=\"0\" />\n";
+  xml << "          <xsd:element name=\"featureID\" "
+      << "type=\"xsd:string\" minOccurs=\"0\" />\n";
+  xml << "        </xsd:sequence>\n";
+  xml << "      </xsd:extension>\n";
+  xml << "    </xsd:complexContent>\n";
+  xml << "  </xsd:complexType>\n";
+  xml << "  <xsd:element name=\"" << escapedTypeName
+      << "\" type=\"qpm:ObjectType\" "
+      << "substitutionGroup=\"gml:AbstractFeature\" />\n";
+  xml << "</xsd:schema>\n";
+
+  util::http::Answer answ("200 OK", xml.str());
+  answ.params["Content-Type"] = "text/xml; charset=UTF-8";
+  answ.params["Cache-Control"] = "no-cache";
+  return answ;
+}
+
+// _____________________________________________________________________________
+util::http::Answer Server::handleWFSGetFeatureReq(
+    const Params& pars, const HeaderParams& headerPars, int sock) const {
+  auto remoteAddr = remoteAddress(sock, headerPars);
+  const std::string* serviceParam = getParamCaseInsensitive(pars, "service");
+  if (serviceParam == nullptr || serviceParam->empty()) {
+    throw std::invalid_argument("No WFS service specified.");
+  }
+
+  if (lower(*serviceParam) != "wfs") {
+    throw std::invalid_argument("Invalid WFS service.");
+  }
+
+  const std::string* versionParam = getParamCaseInsensitive(pars, "version");
+  if (versionParam == nullptr || versionParam->empty()) {
+    throw std::invalid_argument("No WFS version specified.");
+  }
+
+  if (lower(*versionParam) != "2.0.0") {
+    throw std::invalid_argument("Unsupported WFS version.");
+  }
+
+  if (getParamCaseInsensitive(pars, "x") != nullptr &&
+      getParamCaseInsensitive(pars, "y") != nullptr &&
+      getParamCaseInsensitive(pars, "rad") != nullptr) {
+    return handleWFSPickFeatureReq(pars, headerPars, sock);
+  }
+
+  std::string typeName;
+  const std::string* typeNamesParam =
+      getParamCaseInsensitive(pars, "typenames");
+  const std::string* typeNameParam = getParamCaseInsensitive(pars, "typename");
+  if (typeNamesParam != nullptr && !typeNamesParam->empty()) {
+    typeName = *typeNamesParam;
+  } else if (typeNameParam != nullptr && !typeNameParam->empty()) {
+    typeName = *typeNameParam;
+  } else {
+    throw std::invalid_argument("No WFS typename specified.");
+  }
+
+  std::shared_ptr<Requestor> reqor;
+  std::string sessionId = typeName;
+  const std::string prefix = "session_";
+  if (sessionId.rfind(prefix, 0) == 0) {
+    sessionId = sessionId.substr(prefix.size());
+  }
+
+  bool found = false;
+  {
+    std::lock_guard<std::mutex> guard(_m);
+    if (_rs.count(sessionId)) {
+      reqor = _rs.at(sessionId);
+      found = true;
+    }
+  }
+
+  if (!found) {
+    throw std::invalid_argument("WFS type name not found.");
   }
 
   if (!reqor->ready()) {
     throw std::invalid_argument("Session not ready.");
   }
 
-  size_t lid = reqor->getLidById(layer);
-
-  // as soon as we are ready, the reqor can be read concurrently
-  auto res = reqor->getGeom(lid, gid, rad);
-
-  util::json::Val dict;
-
-  if (!noExport) {
-    size_t row;
-    if (gid < reqor->getObjects(lid).size()) {
-      row = reqor->getObjects(lid)[gid].second;
-    } else if (gid - reqor->getObjects(lid).size() <
-               reqor->getDynamicPoints(lid).size()) {
-      row = reqor->getDynamicPoints(lid)[gid - reqor->getObjects(lid).size()]
-                .second;
-    } else {
-      throw std::invalid_argument("Invalid request.");
-    }
-
-    for (auto col : reqor->requestRow(row, remoteAddr)) {
-      dict.dict[col.first] = col.second;
-    }
+  const auto fields = reqor->getLayers();
+  if (fields.empty()) {
+    throw std::invalid_argument("No fields found for WFS type name.");
   }
 
-  std::stringstream json;
+  size_t lid;
 
-  if ((res.poly.size() != 0) + (res.point.size() != 0) +
-          (res.line.size() != 0) >
-      1) {
-    util::geo::Collection<double> col;
-    col.push_back(res.poly);
-    col.push_back(res.line);
-    col.push_back(res.point);
-
-    GeoJsonOutput out(json);
-    out.printLatLng(col, dict);
-  } else if (res.poly.size()) {
-    GeoJsonOutput out(json);
-    out.printLatLng(res.poly, dict);
-  } else if (res.line.size()) {
-    GeoJsonOutput out(json);
-    out.printLatLng(res.line, dict);
+  const std::string* geomFieldParam = getParamCaseInsensitive(pars, "layerid");
+  if (geomFieldParam != nullptr && !geomFieldParam->empty()) {
+    lid = reqor->getLidById(*geomFieldParam);
   } else {
-    GeoJsonOutput out(json);
-    out.printLatLng(res.point, dict);
+    lid = reqor->getLidById(fields[0].id);
   }
 
-  auto answ = util::http::Answer("200 OK", json.str());
-  answ.params["Content-Type"] = "application/json; charset=utf-8";
+  auto layerCfg = reqor->getLayers()[lid];
 
-  if (!noExport) {
-    answ.params["Content-Disposition"] = "attachment;filename:\"export.json\"";
+  auto parseIntParam = [](const std::string& value, const std::string& name) {
+    if (value.empty()) {
+      throw std::invalid_argument("Invalid WFS " + name + " specified.");
+    }
+
+    size_t pos = 0;
+    try {
+      size_t parsed = std::stoull(value, &pos);
+
+      if (pos != value.size()) {
+        throw std::invalid_argument("Invalid WFS " + name + " specified.");
+      }
+
+      return parsed;
+    } catch (...) {
+      throw std::invalid_argument("Invalid WFS " + name + " specified.");
+    }
+  };
+
+  size_t total = reqor->getNumObjects(lid);
+  size_t startIndex = 0;
+
+  const std::string* startIndexParam =
+      getParamCaseInsensitive(pars, "startindex");
+  if (startIndexParam != nullptr && !startIndexParam->empty()) {
+    startIndex = parseIntParam(*startIndexParam, "startindex");
   }
 
+  if (startIndex > total) {
+    startIndex = total;
+  }
+
+  bool hasBbox = false;
+  bool fullExport = false;
+  FBox fbbox;
+  DBox dbbox;
+
+  const std::string* bboxParam = getParamCaseInsensitive(pars, "bbox");
+  const std::string* gidParam = getParamCaseInsensitive(pars, "gid");
+  const std::string* countParam = getParamCaseInsensitive(pars, "count");
+
+  if (bboxParam != nullptr && !bboxParam->empty()) {
+    auto bboxParts = util::split(*bboxParam, ',');
+
+    const std::string* srsParam = getParamCaseInsensitive(pars, "srsName");
+    if (srsParam == nullptr) {
+      srsParam = getParamCaseInsensitive(pars, "crs");
+    }
+    std::string srsName = srsParam != nullptr ? lower(*srsParam) : "epsg:4326";
+    if (bboxParts.size() != 4 && bboxParts.size() != 5) {
+      throw std::invalid_argument("Invalid WFS BBOX specified.");
+    }
+
+    double minX;
+    double minY;
+    double maxX;
+    double maxY;
+
+    if (srsName == "epsg:3857" || srsName == "urn:ogc:def:crs:epsg::3857") {
+      minX = std::atof(bboxParts[0].c_str());
+      minY = std::atof(bboxParts[1].c_str());
+      maxX = std::atof(bboxParts[2].c_str());
+      maxY = std::atof(bboxParts[3].c_str());
+    } else {
+      double minLon = std::atof(bboxParts[0].c_str());
+      double minLat = std::atof(bboxParts[1].c_str());
+      double maxLon = std::atof(bboxParts[2].c_str());
+      double maxLat = std::atof(bboxParts[3].c_str());
+
+      auto lowerLeft = latLngToWebMerc<double>(minLat, minLon);
+      auto upperRight = latLngToWebMerc<double>(maxLat, maxLon);
+
+      minX = lowerLeft.getX();
+      minY = lowerLeft.getY();
+      maxX = upperRight.getX();
+      maxY = upperRight.getY();
+    }
+
+    double normMinX = std::min(minX, maxX);
+    double normMinY = std::min(minY, maxY);
+    double normMaxX = std::max(minX, maxX);
+    double normMaxY = std::max(minY, maxY);
+
+    fbbox = FBox({static_cast<float>(normMinX), static_cast<float>(normMinY)},
+                 {static_cast<float>(normMaxX), static_cast<float>(normMaxY)});
+    dbbox = DBox({normMinX, normMinY}, {normMaxX, normMaxY});
+
+    hasBbox = true;
+  }
+
+  std::vector<size_t> featureIds;
+
+   if (hasBbox) {
+    // select by bounding box
+    std::unordered_set<ID_TYPE> candidates;
+
+    if (intersects(reqor->getPointGrid(lid).getBBox(), fbbox)) {
+      reqor->getPointGrid(lid).get(fbbox, &candidates);
+    }
+
+    if (intersects(reqor->getLineGrid(lid).getBBox(), fbbox)) {
+      reqor->getLineGrid(lid).get(fbbox, &candidates);
+    }
+
+    std::vector<ID_TYPE> sortedCandidates(candidates.begin(), candidates.end());
+    std::sort(sortedCandidates.begin(), sortedCandidates.end());
+
+    for (auto candidateOid : sortedCandidates) {
+      size_t oid = candidateOid;
+      if (reqor->isCluster(lid, oid)) oid = reqor->getCluster(lid, oid).first;
+      if (oid >= reqor->getNumObjects(lid)) continue;
+
+      bool include = false;
+
+      if (oid < reqor->getObjects(lid).size()) {
+        auto geomId = reqor->getObjects(lid)[oid].first;
+
+        if (geomId < I_OFFSET) {
+          auto p = reqor->getPoint(lid, oid);
+          include = contains(p, fbbox);
+        } else {
+          include = reqor->lineIntersects(geomId, dbbox);
+        }
+      } else {
+        auto p = reqor->getPoint(lid, oid);
+        include = contains(p, fbbox);
+      }
+
+      if (include) {
+        featureIds.push_back(oid);
+      }
+    }
+  } else if (gidParam != nullptr && !gidParam->empty()) {
+    // select by ID
+    const size_t gid = parseIntParam(*gidParam, "gid");
+    const size_t selectableTotal =
+        reqor->getObjects(lid).size() + reqor->getDynamicPoints(lid).size();
+    if (gid >= selectableTotal) {
+      throw std::invalid_argument("Invalid WFS gid specified.");
+    }
+    featureIds = {gid};
+  } else {
+    fullExport = true;
+  }
+
+  size_t featureStart = std::min(startIndex, featureIds.size());
+  size_t featureEnd = featureIds.size();
+
+  if (countParam != nullptr && !countParam->empty()) {
+    size_t count = parseIntParam(*countParam, "count");
+    if (count < featureIds.size() - featureStart) {
+      featureEnd = featureStart + count;
+    }
+  }
+
+  auto answ = util::http::Answer("200 OK", "");
+  answ.params["Content-Encoding"] = "identity";
+  answ.params["Content-Type"] = "application/json; charset=UTF-8";
+  answ.params["Cache-Control"] = "no-cache";
+  answ.params["Server"] = "qlever-petrimaps";
+  answ.params["Content-Disposition"] = "attachment;filename:\"export.json\"";
+
+  // we do not set the Content-Length header here, but serve until
+  // we are done. In particular, we do not need to send our data in chunks, as
+  // specified by https://www.rfc-editor.org/rfc/rfc7230#section-3.3.3
+  // point 7
+
+  std::stringstream head;
+  head << "HTTP/1.1 " << answ.status << "\r\n";
+  for (const auto& kv : answ.params)
+    head << kv.first << ": " << kv.second << "\r\n";
+
+  head << "\r\n";
+  head << "{\"type\":\"FeatureCollection\",\"features\":[";
+
+  sendRaw(sock, head.str());
+
+  bool first = false;
+
+  if (fullExport) {
+    size_t oid = 0;
+    reqor->requestRows(
+        [sock, &first, &oid, &sessionId, &layerCfg](
+            std::vector<std::vector<std::pair<std::string, std::string>>>
+                rows) {
+          std::stringstream json;
+          json << std::setprecision(10);
+
+          for (const auto& row : rows) {
+            if (row.empty()) continue;
+
+            util::json::Val dict;
+
+            size_t geomField = row.size() - 1;
+
+            for (size_t i = 0; i < row.size(); i++) {
+              if (row[i].first == layerCfg.geomField) {
+                geomField = i;
+                // skip WKT field here, is redundant in GeoJSON
+                continue;
+              }
+              dict.dict[row[i].first] = row[i].second;
+            }
+
+            dict.dict["gid"] = oid;
+            dict.dict["featureID"] = sessionId + "::" + std::to_string(oid);
+
+            if (row[geomField].second.size()) {
+              first = printWKTFeature(json, row[geomField].second, dict, first);
+              json << "\n";
+            }
+
+            oid++;
+          }
+
+          if (json.str().size() != 0) sendRaw(sock, json.str());
+        },
+        remoteAddr);
+  } else {
+    for (size_t idx = featureStart; idx < featureEnd; idx++) {
+      size_t oid = featureIds[idx];
+      std::string featureId = sessionId + "::" + std::to_string(oid);
+
+      util::json::Val dict;
+      dict.dict["gid"] = oid;
+      dict.dict["featureID"] = featureId;
+
+      size_t row = reqor->getRow(lid, oid);
+
+      for (const auto& col : reqor->requestRow(row, remoteAddr)) {
+        if (col.first == layerCfg.geomField) {
+          // skip WKT field here, is redundant in GeoJSON
+          continue;
+        }
+        dict.dict[col.first] = col.second;
+      }
+
+      auto res = reqor->getGeom(lid, oid, 0);
+
+      std::stringstream json;
+
+      if (first) json << ",";
+      first = true;
+
+      if ((res.poly.size() != 0) + (res.point.size() != 0) +
+              (res.line.size() != 0) >
+          1) {
+        util::geo::Collection<double> col;
+        col.push_back(res.poly);
+        col.push_back(res.line);
+        col.push_back(res.point);
+
+        GeoJsonOutput out(json, true);
+        out.printLatLng(col, dict);
+      } else if (res.poly.size()) {
+        GeoJsonOutput out(json, true);
+        out.printLatLng(res.poly, dict);
+      } else if (res.line.size()) {
+        GeoJsonOutput out(json, true);
+        out.printLatLng(res.line, dict);
+      } else if (res.point.size()) {
+        GeoJsonOutput out(json, true);
+        out.printLatLng(res.point, dict);
+      }
+
+      sendRaw(sock, json.str());
+    }
+  }
+
+  sendRaw(sock, "]}");
+
+  answ.raw = true;
   return answ;
+}
+
+// _____________________________________________________________________________
+std::string Server::getHeatLayer(const std::string& layer) const {
+  std::string heatLayer = layer;
+
+  if (layer.find('-') == std::string::npos) {
+    std::shared_ptr<Requestor> reqor;
+    {
+      std::lock_guard<std::mutex> guard(_m);
+      if (!_rs.count(layer)) {
+        throw std::invalid_argument("Session not found.");
+      }
+      reqor = _rs[layer];
+    }
+
+    const auto layers = reqor->getLayers();
+    if (layers.empty()) {
+      throw std::invalid_argument("No fields found for session.");
+    }
+
+    heatLayer = layer + "-" + layers[0].id;
+  }
+  return heatLayer;
+}
+
+// _____________________________________________________________________________
+uint64_t Server::validateTileCoordinates(int x, int y, int z) {
+  if (x < 0 || y < 0 || z < 0)
+    throw std::invalid_argument("Invalid tile coordinates.");
+
+  if (z >= 31) throw std::invalid_argument("Zoom level too large.");
+
+  uint64_t tilesPerAxis = 1ULL << z;
+  if (static_cast<uint64_t>(x) >= tilesPerAxis ||
+      static_cast<uint64_t>(y) >= tilesPerAxis) {
+    throw std::invalid_argument("Tile coordinates out of ranges.");
+  }
+  return tilesPerAxis;
+}
+
+// _____________________________________________________________________________
+std::string Server::getWebMercatorTileBbox(int x, int topOriginY, int z) {
+  uint64_t tilesPerAxis = validateTileCoordinates(x, topOriginY, z);
+
+  const double WEBMERC_MIN = -20037508.342789244;
+  const double WEBMERC_MAX = 20037508.342789244;
+  const double WORLD_SIZE = WEBMERC_MAX - WEBMERC_MIN;
+
+  double tileSize = WORLD_SIZE / static_cast<double>(tilesPerAxis);
+
+  double x1 = WEBMERC_MIN + x * tileSize;
+  double x2 = WEBMERC_MIN + (x + 1) * tileSize;
+
+  double yTop = WEBMERC_MAX - topOriginY * tileSize;
+  double yBottom = WEBMERC_MAX - (topOriginY + 1) * tileSize;
+
+  std::stringstream bboxSs;
+  bboxSs << std::setprecision(15) << x1 << "," << yBottom << "," << x2 << ","
+         << yTop;
+
+  return bboxSs.str();
+}
+
+// _____________________________________________________________________________
+std::string Server::xmlEscape(const std::string& value) {
+  std::string escaped;
+  for (char c : value) {
+    switch (c) {
+      case '&':
+        escaped += "&amp;";
+        break;
+      case '<':
+        escaped += "&lt;";
+        break;
+      case '>':
+        escaped += "&gt;";
+        break;
+      case '"':
+        escaped += "&quot;";
+        break;
+      case '\'':
+        escaped += "&apos;";
+        break;
+      default:
+        escaped += c;
+        break;
+    }
+  }
+  return escaped;
+}
+
+// _____________________________________________________________________________
+std::string Server::urlEncode(const std::string& value) {
+  std::stringstream encoded;
+
+  for (unsigned char c : value) {
+    if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+        (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' ||
+        c == '~') {
+      encoded << c;
+    } else {
+      encoded << '%' << std::uppercase << std::hex << std::setw(2)
+              << std::setfill('0') << static_cast<int>(c) << std::nouppercase
+              << std::dec;
+    }
+  }
+  return encoded.str();
+}
+
+// _____________________________________________________________________________
+util::http::Answer Server::handleTMSReq(const Params& pars, int sock) const {
+  if (pars.count("layers") == 0 || pars.find("layers")->second.empty())
+    throw std::invalid_argument("No layer id specified.");
+
+  if (pars.count("styles") == 0 || pars.find("styles")->second.empty())
+    throw std::invalid_argument("No style specified.");
+
+  if (pars.count("x") == 0 || pars.find("x")->second.empty())
+    throw std::invalid_argument("No x specified.");
+
+  if (pars.count("y") == 0 || pars.find("y")->second.empty())
+    throw std::invalid_argument("No y specified.");
+
+  if (pars.count("z") == 0 || pars.find("z")->second.empty())
+    throw std::invalid_argument("No z specified.");
+
+  std::string id = pars.find("layers")->second;
+
+  int x = atoi(pars.find("x")->second.c_str());
+  int y = atoi(pars.find("y")->second.c_str());
+  int z = atoi(pars.find("z")->second.c_str());
+
+  uint64_t tilesPerAxis = validateTileCoordinates(x, y, z);
+  int topOriginY = static_cast<int>(tilesPerAxis - 1 - y);
+  std::string bbox = getWebMercatorTileBbox(x, topOriginY, z);
+
+  Params heatPars = pars;
+  heatPars["bbox"] = bbox;
+  heatPars["width"] = "256";
+  heatPars["height"] = "256";
+
+  return handleHeatMapReq(heatPars, sock);
 }
 
 // _____________________________________________________________________________
 util::http::Answer Server::handlePosReq(const Params& pars,
                                         const HeaderParams& headers,
                                         int sock) const {
+  return handleNearestFeatureReq(pars, headers, sock, false);
+}
+
+// _____________________________________________________________________________
+util::http::Answer Server::handleTouchReq(const Params& pars,
+                                          const HeaderParams& headerParams,
+                                          int sock) const {
+  auto remoteAddr = remoteAddress(sock, headerParams);
+
+  if (pars.count("backend") == 0 || pars.find("backend")->second.empty())
+    throw std::invalid_argument("No backend (?backend=) specified.");
+
+  const std::string& backend = pars.find("backend")->second;
+
+  std::string accessToken;
+  if (headerParams.count("Authorization") != 0 &&
+      !headerParams.find("Authorization")->second.empty()) {
+    accessToken = headerParams.find("Authorization")->second;
+  }
+
+  std::string configJson;
+  if (pars.find("cfg") != pars.end()) {
+    configJson = pars.find("cfg")->second;
+  }
+
+  auto backendCfg =
+      getGeomCacheConfig(backend, accessToken, configJson, remoteAddr);
+
+  createCache(backendCfg);
+  std::shared_ptr<GeomCache> cache = _caches[backend];
+
+  std::stringstream ss;
+  ss << "{\"config\":";
+  ss << backendCfg.toJSON();
+  ss << ", \"loaded\": " << cache->getLoadStatusPercent(true);
+  ss << "}";
+
+  auto answ = util::http::Answer("200 OK", ss.str());
+  answ.params["Content-Type"] = "application/json; charset=utf-8";
+
+  return answ;
+}
+// _____________________________________________________________________________
+util::http::Answer Server::handleWFSPickFeatureReq(const Params& pars,
+                                                   const HeaderParams& headers,
+                                                   int sock) const {
+  return handleNearestFeatureReq(pars, headers, sock, true);
+}
+// _____________________________________________________________________________
+util::http::Answer Server::handleNearestFeatureReq(const Params& pars,
+                                                   const HeaderParams& headers,
+                                                   int sock,
+                                                   bool isWfsRequest) const {
   auto remoteAddr = remoteAddress(sock, headers);
 
   if (pars.count("x") == 0 || pars.find("x")->second.empty())
@@ -786,7 +1909,7 @@ util::http::Answer Server::handlePosReq(const Params& pars,
 
   if (pars.count("rad") == 0 || pars.find("rad")->second.empty())
     throw std::invalid_argument("No rad (?rad=) specified.");
-  auto rad = std::atof(pars.find("rad")->second.c_str());
+  float rad = std::atof(pars.find("rad")->second.c_str());
 
   if (pars.count("width") == 0 || pars.find("width")->second.empty())
     throw std::invalid_argument("No width (?width=) specified.");
@@ -798,6 +1921,18 @@ util::http::Answer Server::handlePosReq(const Params& pars,
   auto box = util::split(pars.find("bbox")->second, ',');
 
   if (box.size() != 4) throw std::invalid_argument("Invalid request.");
+  if (isWfsRequest) {
+    const std::string* srsParam = getParamCaseInsensitive(pars, "srsName");
+    if (srsParam == nullptr) {
+      srsParam = getParamCaseInsensitive(pars, "crs");
+    }
+
+    std::string srsName = srsParam != nullptr ? lower(*srsParam) : "epsg:3857";
+
+    if (srsName != "epsg:3857" && srsName != "urn:ogc:def:crs:epsg::3857") {
+      throw std::invalid_argument("WFS pick requires EPSG:3857 coordinates.");
+    }
+  }
 
   double x1 = std::atof(box[0].c_str());
   double y1 = std::atof(box[1].c_str());
@@ -816,7 +1951,7 @@ util::http::Answer Server::handlePosReq(const Params& pars,
   // res of -1 means dont render clusters
   if (reso >= THRESHOLD) reso = -1;
 
-  LOG(DEBUG) << "[SERVER] Click at " << x << ", " << y;
+  LOG(DEBUG) << "[SERVER] WFS pick at " << x << ", " << y;
 
   std::shared_ptr<Requestor> reqor;
   {
@@ -834,7 +1969,55 @@ util::http::Answer Server::handlePosReq(const Params& pars,
   }
   // as soon as we are ready, the reqor can be read concurrently
 
+  LOG(INFO) << "Looking up nearest geometry...";
   auto res = reqor->getNearest({x, y}, rad, reso, fbbox, remoteAddr);
+  LOG(INFO) << "Got nearest geometry...";
+
+  if (isWfsRequest) {
+    std::stringstream json;
+    json << "{\"type\":\"FeatureCollection\",\"features\":[";
+
+    if (res.has) {
+      util::json::Val dict;
+
+      dict.dict["id"] = std::to_string(res.id);
+      dict.dict["geomfield"] = reqor->getLayers()[res.fieldId].geomField;
+
+      auto ll = webMercToLatLng<float>(res.pos.getX(), res.pos.getY());
+      dict.dict["popup_lat"] = std::to_string(ll.getY());
+      dict.dict["popup_lng"] = std::to_string(ll.getX());
+
+      for (const auto& kv : res.cols) {
+        dict.dict[kv.first] = kv.second;
+      }
+
+      if ((res.poly.size() != 0) + (res.point.size() != 0) +
+              (res.line.size() != 0) >
+          1) {
+        util::geo::Collection<double> col;
+        col.push_back(res.poly);
+        col.push_back(res.line);
+        col.push_back(res.point);
+
+        GeoJsonOutput out(json, true);
+        out.printLatLng(col, dict);
+      } else if (res.poly.size()) {
+        GeoJsonOutput out(json, true);
+        out.printLatLng(res.poly, dict);
+      } else if (res.line.size()) {
+        GeoJsonOutput out(json, true);
+        out.printLatLng(res.line, dict);
+      } else {
+        GeoJsonOutput out(json, true);
+        out.printLatLng(res.point, dict);
+      }
+    }
+    json << "]}";
+
+    auto answ = util::http::Answer("200 OK", json.str());
+    answ.params["Content-Type"] = "application/json; charset=utf-8";
+    return answ;
+  }
 
   std::stringstream json;
 
@@ -895,46 +2078,6 @@ util::http::Answer Server::handlePosReq(const Params& pars,
   json << "]";
 
   auto answ = util::http::Answer("200 OK", json.str());
-  answ.params["Content-Type"] = "application/json; charset=utf-8";
-
-  return answ;
-}
-
-// _____________________________________________________________________________
-util::http::Answer Server::handleTouchReq(const Params& pars,
-                                          const HeaderParams& headerParams,
-                                          int sock) const {
-  auto remoteAddr = remoteAddress(sock, headerParams);
-
-  if (pars.count("backend") == 0 || pars.find("backend")->second.empty())
-    throw std::invalid_argument("No backend (?backend=) specified.");
-
-  const std::string& backend = pars.find("backend")->second;
-
-  std::string accessToken;
-  if (headerParams.count("Authorization") != 0 &&
-      !headerParams.find("Authorization")->second.empty()) {
-    accessToken = headerParams.find("Authorization")->second;
-  }
-
-  std::string configJson;
-  if (pars.find("cfg") != pars.end()) {
-    configJson = pars.find("cfg")->second;
-  }
-
-  auto backendCfg =
-      getGeomCacheConfig(backend, accessToken, configJson, remoteAddr);
-
-  createCache(backendCfg);
-  std::shared_ptr<GeomCache> cache = _caches[backend];
-
-  std::stringstream ss;
-  ss << "{\"config\":";
-  ss << backendCfg.toJSON();
-  ss << ", \"loaded\": " << cache->getLoadStatusPercent(true);
-  ss << "}";
-
-  auto answ = util::http::Answer("200 OK", ss.str());
   answ.params["Content-Type"] = "application/json; charset=utf-8";
 
   return answ;
@@ -1277,158 +2420,6 @@ void Server::clearOldSessions() const {
       clearSession(id);
     }
   }
-}
-
-// _____________________________________________________________________________
-util::http::Answer Server::handleExportReq(const Params& pars,
-                                           const HeaderParams& headers,
-                                           int sock) const {
-  // ignore SIGPIPE
-  signal(SIGPIPE, SIG_IGN);
-
-  auto aw = util::http::Answer("200 OK", "");
-
-  auto remoteAddr = remoteAddress(sock, headers);
-
-  if (pars.count("id") == 0 || pars.find("id")->second.empty())
-    throw std::invalid_argument("No session id (?id=) specified.");
-  auto id = pars.find("id")->second;
-
-  std::shared_ptr<Requestor> reqor;
-
-  {
-    std::lock_guard<std::mutex> guard(_m);
-    bool has = _rs.count(id);
-    if (!has) {
-      LOG(ERROR) << "Session " << id << " not found!";
-      throw std::invalid_argument("Session not found");
-    }
-    reqor = _rs[id];
-  }
-
-  if (!reqor->ready()) {
-    throw std::invalid_argument("Session not ready.");
-  }
-  // as soon as we are ready, the reqor can be read concurrently
-
-  aw.params["Content-Encoding"] = "identity";
-  aw.params["Content-Type"] = "application/json";
-  aw.params["Content-Disposition"] = "attachment;filename:\"export.json\"";
-  aw.params["Server"] = "qlever-petrimaps";
-
-  // we do not set the Content-Length header here, but serve until
-  // we are done. In particular, we do not need to send our data in chunks, as
-  // specified by https://www.rfc-editor.org/rfc/rfc7230#section-3.3.3
-  // point 7
-
-  std::stringstream ss;
-  ss << "HTTP/1.1 " << aw.status << "\r\n";
-  for (const auto& kv : aw.params)
-    ss << kv.first << ": " << kv.second << "\r\n";
-
-  ss << "\r\n";
-  ss << "{\"type\":\"FeatureCollection\",\"features\":[";
-
-  std::string buff = ss.str();
-
-  size_t writes = 0;
-
-  while (writes != buff.size()) {
-    int64_t out =
-        send(sock, buff.c_str() + writes, buff.size() - writes, MSG_NOSIGNAL);
-    if (out < 0) {
-      if (errno == EWOULDBLOCK || errno == EAGAIN || errno == EINTR) continue;
-      throw std::runtime_error("Failed to write to socket");
-    }
-    writes += out;
-  }
-
-  bool first = false;
-
-  reqor->requestRows(
-      [sock, &first](
-          std::vector<std::vector<std::pair<std::string, std::string>>> rows) {
-        std::stringstream ss;
-        ss << std::setprecision(10);
-
-        util::json::Val dict;
-
-        for (const auto& row : rows) {
-          // skip last entry, which is the WKT
-          for (size_t i = 0; i < row.size() - 1; i++) {
-            dict.dict[row[i].first] = row[i].second;
-          }
-
-          GeoJsonOutput geoJsonOut(ss, true);
-
-          const char* s = row[row.size() - 1].second.c_str();
-
-          if (*s == '"') s++;  // drop " at beginning
-
-          auto wktType = util::geo::getWKTType(s, &s);
-
-          if (wktType != util::geo::WKTType::NONE) {
-            if (first) ss << ",";
-            first = true;
-          }
-
-          if (wktType == util::geo::WKTType::POLYGON) {
-            geoJsonOut.print(util::geo::polygonFromWKT<double>(s, 0), dict);
-          }
-          if (wktType == util::geo::WKTType::MULTIPOLYGON) {
-            geoJsonOut.print(util::geo::multiPolygonFromWKT<double>(s, 0),
-                             dict);
-          }
-          if (wktType == util::geo::WKTType::POINT) {
-            geoJsonOut.print(util::geo::pointFromWKT<double>(s, 0), dict);
-          }
-          if (wktType == util::geo::WKTType::MULTIPOINT) {
-            geoJsonOut.print(util::geo::multiPointFromWKT<double>(s, 0), dict);
-          }
-          if (wktType == util::geo::WKTType::LINESTRING) {
-            geoJsonOut.print(util::geo::lineFromWKT<double>(s, 0), dict);
-          }
-          if (wktType == util::geo::WKTType::MULTILINESTRING) {
-            geoJsonOut.print(util::geo::multiLineFromWKT<double>(s, 0), dict);
-          }
-          if (wktType == util::geo::WKTType::COLLECTION) {
-            geoJsonOut.print(util::geo::collectionFromWKT<double>(s, 0), dict);
-          }
-          ss << "\n";
-        }
-
-        std::string buff = ss.str();
-
-        size_t writes = 0;
-
-        while (writes != buff.size()) {
-          int64_t out = send(sock, buff.c_str() + writes, buff.size() - writes,
-                             MSG_NOSIGNAL);
-          if (out < 0) {
-            if (errno == EWOULDBLOCK || errno == EAGAIN || errno == EINTR)
-              continue;
-            throw std::runtime_error("Failed to write to socket");
-          }
-          writes += out;
-        }
-      },
-      remoteAddr);
-
-  buff = "]}";
-  writes = 0;
-
-  while (writes != buff.size()) {
-    int64_t out =
-        send(sock, buff.c_str() + writes, buff.size() - writes, MSG_NOSIGNAL);
-    if (out < 0) {
-      if (errno == EWOULDBLOCK || errno == EAGAIN || errno == EINTR) continue;
-      throw std::runtime_error("Failed to write to socket");
-    }
-    writes += out;
-  }
-
-  aw.raw = true;
-  return aw;
 }
 
 // _____________________________________________________________________________

--- a/src/qlever-petrimaps/server/Server.h
+++ b/src/qlever-petrimaps/server/Server.h
@@ -82,6 +82,7 @@ class Server : public util::http::Handler {
   RequestorConfig getRequestorCfgFromJSON(const std::string& json) const;
   GeomCacheConfig getGeomCacheCfgFromJSON(const std::string& backend,
                                           const std::string& json) const;
+  RequestorConfig getDefaultRequestorCfg(const std::string& backend, const std::string& query) const;
 
   static void pngWriteRowCb(png_structp png_ptr, png_uint_32 row, int pass);
   void writePNG(const unsigned char* data, size_t w, size_t h, int sock) const;

--- a/src/qlever-petrimaps/server/Server.h
+++ b/src/qlever-petrimaps/server/Server.h
@@ -42,6 +42,32 @@ class Server : public util::http::Handler {
                                     const HeaderParams& headerPars,
                                     int sock) const;
   util::http::Answer handleHeatMapReq(const Params& pars, int sock) const;
+  util::http::Answer handleTMSReq(const Params& pars, int sock) const;
+  util::http::Answer handleWMTSReq(const Params& pars, int sock) const;
+  util::http::Answer handleWMTSGetTileReq(const Params& pars, int sock) const;
+  util::http::Answer handleWMTSGetCapabilitiesReq(const Params& pars) const;
+  util::http::Answer handleWFSReq(const Params& pars,
+                                  const HeaderParams& headerPars,
+                                  int sock) const;
+  util::http::Answer handleWFSGetCapabilitiesReq(const Params& pars) const;
+  util::http::Answer handleWFSDescribeFeatureTypeReq(const Params& pars) const;
+  util::http::Answer handleWFSGetFeatureReq(const Params& pars,
+                                            const HeaderParams& headerPars,
+                                            int sock) const;
+  util::http::Answer handleWFSPickFeatureReq(const Params& pars,
+                                            const HeaderParams& headerPars,
+                                            int sock) const;
+  util::http::Answer handleNearestFeatureReq(const Params& pars,
+                                             const HeaderParams& headerPars,
+                                             int sock,
+                                             bool isWfsRequest) const;
+
+  std::string getHeatLayer(const std::string& layer) const;
+  static uint64_t validateTileCoordinates(int x, int y, int z);
+  static std::string getWebMercatorTileBbox(int x, int topOriginY, int z);
+  static std::string xmlEscape(const std::string& value);
+  static std::string urlEncode(const std::string& value);
+
   util::http::Answer handleQueryReq(const Params& pars,
                                     const HeaderParams& headerPars,
                                     int sock) const;

--- a/src/qlever-petrimaps/server/Server.h
+++ b/src/qlever-petrimaps/server/Server.h
@@ -77,9 +77,6 @@ class Server : public util::http::Handler {
   util::http::Answer handleClearSessReq(const Params& pars,
                                         const HeaderParams& headerPars,
                                         int sock) const;
-  util::http::Answer handlePosReq(const Params& pars,
-                                  const HeaderParams& headerPars,
-                                  int sock) const;
   util::http::Answer handleLoadReq(const Params& pars, int sock) const;
 
   util::http::Answer handleExportReq(const Params& pars,

--- a/web/example.html
+++ b/web/example.html
@@ -48,6 +48,15 @@
       border: none;
       background-color: default;
     }
+
+    .tabs button {
+      width: auto;
+    }
+
+    .tabs button.active {
+      background-color: #ccc;
+      font-weight: bold;
+    }
   </style>
 </head>
 <body>
@@ -55,8 +64,14 @@
     <h2>petrimaps integration example</h2>
 
     <form>
-      <label for="config">Requestor config JSON</label>
-      <textarea id="config" name="cfg">
+      <label>Requestor config JSON</label>
+
+      <div class="tabs">
+        <button type="button" class="active" onclick="showTab(0)">Example 1</button>
+        <button type="button" onclick="showTab(1)">Example 2</button>
+      </div>
+
+      <textarea class="config" id="config1" name="cfg">
 {
   "query" : "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\nPREFIX osm: <https://www.openstreetmap.org/>\nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\nPREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>\nPREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>\nSELECT ?country ?admin_level ?area ?geom WHERE {\n  ?country osmkey:admin_level ?admin_level .\n  ?country rdf:type osm:relation .                                                                                                                                                                                 \n  ?country osmkey:name ?name . \n  ?country osm2rdf:area ?area . \n  ?country geo:hasGeometry/geo:asWKT ?geom . \n  ?country osmkey:start_date ?start_date .                                                              \n  ?country osmkey:end_date ?end_date .   \n  VALUES ?date { \"1900-01-01\"^^xsd:date } \n  FILTER (?date >= xsd:date(?start_date) && ?date <= xsd:date(?end_date))                                                                                                                                          \n}",
   "layers" : [
@@ -104,6 +119,112 @@
 }
 </textarea>
 
+      <textarea class="config" id="config2" name="cfg" hidden disabled>
+{
+  "query" : "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\nPREFIX osm: <https://www.openstreetmap.org/>\nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\nPREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>\nPREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>\nSELECT ?country ?admin_level ?area ?geom WHERE {\n  ?country osmkey:admin_level ?admin_level .\n  ?country rdf:type osm:relation .                                                                                                                                                                                 \n  ?country osmkey:name ?name . \n  ?country osm2rdf:area ?area . \n  ?country geo:hasGeometry/geo:asWKT ?geom . \n  ?country osmkey:start_date ?start_date .                                                              \n  ?country osmkey:end_date ?end_date .   \n  VALUES ?date { \"1900-01-01\"^^xsd:date } \n  FILTER (?date >= xsd:date(?start_date) && ?date <= xsd:date(?end_date))                                                                                                                                          \n}",
+  "layers" : [
+    {
+        "name" : "?geom linew=0",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 0,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=1",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 1,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=2",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 2,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=3",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 3,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=4",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 4,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=5",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 5,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=6",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 6,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=7",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 7,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=8",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 8,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=9",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 9,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=10",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 10,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=20",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 20,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=50",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 50,
+        "fillopacity" : 0.5
+    },
+    {
+        "name" : "?geom linew=100",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : 100,
+        "fillopacity" : 0.5
+    }
+  ]
+}
+</textarea>
+
       <label for="backend">QLever backend</label>
       <input type="text" id="backend" name="backend" value="https://qlever.dev/api/ohm-planet" />
 
@@ -121,6 +242,18 @@
   </div>
 
   <script>
+    // only the config of the active tab is part of the form data
+    function showTab(i) {
+      document.querySelectorAll('.tabs button').forEach((tab, j) => {
+        tab.classList.toggle('active', i === j);
+      });
+
+      document.querySelectorAll('textarea.config').forEach((area, j) => {
+        area.hidden = i !== j;
+        area.disabled = i !== j;
+      });
+    }
+
     function submitForm() {
       const form = document.getElementsByTagName('form')[0];
       const method = document.querySelector('input[name="method"]:checked').value;

--- a/web/example.html
+++ b/web/example.html
@@ -67,6 +67,7 @@
       <label>Requestor config JSON</label>
 
       <div class="tabs">
+        <button type="button" class="active" onclick="showTab(0)">Various layers</button>
         <button type="button" onclick="showTab(1)">Object styles</button>
       </div>
 

--- a/web/example.html
+++ b/web/example.html
@@ -67,8 +67,7 @@
       <label>Requestor config JSON</label>
 
       <div class="tabs">
-        <button type="button" class="active" onclick="showTab(0)">Example 1</button>
-        <button type="button" onclick="showTab(1)">Example 2</button>
+        <button type="button" onclick="showTab(1)">Object styles</button>
       </div>
 
       <textarea class="config" id="config1" name="cfg">
@@ -121,108 +120,383 @@
 
       <textarea class="config" id="config2" name="cfg" hidden disabled>
 {
-  "query" : "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\nPREFIX osm: <https://www.openstreetmap.org/>\nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\nPREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>\nPREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>\nSELECT ?country ?admin_level ?area ?geom WHERE {\n  ?country osmkey:admin_level ?admin_level .\n  ?country rdf:type osm:relation .                                                                                                                                                                                 \n  ?country osmkey:name ?name . \n  ?country osm2rdf:area ?area . \n  ?country geo:hasGeometry/geo:asWKT ?geom . \n  ?country osmkey:start_date ?start_date .                                                              \n  ?country osmkey:end_date ?end_date .   \n  VALUES ?date { \"1900-01-01\"^^xsd:date } \n  FILTER (?date >= xsd:date(?start_date) && ?date <= xsd:date(?end_date))                                                                                                                                          \n}",
+  "query" : "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\nPREFIX osm: <https://www.openstreetmap.org/>\nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\nPREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>\nPREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>\nSELECT * WHERE {\n{\nSELECT ?country ?admin_level ?area ?geom WHERE {\n ?country osmkey:admin_level ?admin_level .\n ?country rdf:type osm:relation .\n ?country osmkey:name ?name .\n ?country osm2rdf:area ?area .\n ?country geo:hasGeometry/geo:asWKT ?geom .\n ?country osmkey:start_date ?start_date .\n ?country osmkey:end_date ?end_date .\n VALUES ?date { \"1900-01-01\"^^xsd:date }\n FILTER (?date >= xsd:date(?start_date) && ?date <= xsd:date(?end_date))\n}\n}\nUNION {\nSELECT ?station ?name ?stationgeom WHERE {\n ?station rdf:type osm:node .\n ?station osmkey:name ?name .\n ?station geo:hasGeometry/geo:asWKT ?stationgeom .\n ?station osmkey:start_date ?start_date .\n ?station osmkey:end_date ?end_date .\n ?station osmkey:train \"yes\" .\n\n VALUES ?date { \"1900-01-01\"^^xsd:date }\n FILTER (?date >= xsd:date(?start_date) && ?date <= xsd:date(?end_date))\n}\n}\n}",
   "layers" : [
     {
-        "name" : "?geom linew=0",
+        "name" : "linew=-1",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "linew" : -1,
+        "fillopacity" : 0.5,
+        "group" : "Line width"
+    },
+    {
+        "name" : "linew=0",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 0,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=1",
+        "name" : "linew=1",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 1,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=2",
+        "name" : "linew=2",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 2,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=3",
+        "name" : "linew=3",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 3,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=4",
+        "name" : "linew=4",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 4,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=5",
+        "name" : "linew=5",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 5,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=6",
+        "name" : "linew=6",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 6,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=7",
+        "name" : "linew=7",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 7,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=8",
+        "name" : "linew=8",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 8,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=9",
+        "name" : "linew=9",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 9,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=10",
+        "name" : "linew=10",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 10,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=20",
+        "name" : "linew=20",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 20,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=50",
+        "name" : "linew=50",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 50,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
     },
     {
-        "name" : "?geom linew=100",
+        "name" : "linew=100",
         "geomfield" : "?geom",
         "style" : "objects",
         "linew" : 100,
-        "fillopacity" : 0.5
+        "fillopacity" : 0.5,
+        "group" : "Line width"
+    },
+    {
+        "name" : "fillopacity=-1",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : -1,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0.1",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0.1,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0.2",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0.2,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0.3",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0.3,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0.4",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0.4,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0.5",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0.5,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0.6",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0.6,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0.7",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0.7,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0.8",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0.8,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=0.9",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 0.9,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=1.0",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 1,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "fillopacity=1.1",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "fillopacity" : 1.1,
+        "group" : "Fill opacity"
+    },
+    {
+        "name" : "lineopacity=-1",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : -1,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0.1",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0.1,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0.2",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0.2,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0.3",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0.3,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0.4",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0.4,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0.5",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0.5,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0.6",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0.6,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0.7",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0.7,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0.8",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0.8,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=0.9",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 0.9,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=1.0",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 1,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "lineopacity=1.1",
+        "geomfield" : "?geom",
+        "style" : "objects",
+        "lineopacity" : 1.1,
+        "group" : "Line opacity"
+    },
+    {
+        "name" : "pointradius=0",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 0,
+        "group" : "Point radius"
+    },
+    {
+        "name" : "pointradius=1",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 1,
+        "group" : "Point radius"
+    },
+    {
+        "name" : "pointradius=2",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 2,
+        "group" : "Point radius"
+    },
+    {
+        "name" : "pointradius=3",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 3,
+        "group" : "Point radius"
+    },
+    {
+        "name" : "pointradius=4",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 4,
+        "group" : "Point radius"
+    },
+    {
+        "name" : "pointradius=5",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 5,
+        "group" : "Point radius"
+    },
+    {
+        "name" : "pointradius=10",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 10,
+        "group" : "Point radius"
+    },
+    {
+        "name" : "pointradius=20",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 20,
+        "group" : "Point radius"
+    },
+    {
+        "name" : "pointradius=50",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 50,
+        "group" : "Point radius"
+    },
+    {
+        "name" : "pointradius=100",
+        "geomfield" : "?stationgeom",
+        "style" : "objects",
+		"pointradius" : 100,
+        "group" : "Point radius"
     }
   ]
 }
+
 </textarea>
 
       <label for="backend">QLever backend</label>

--- a/web/index.html
+++ b/web/index.html
@@ -20,9 +20,10 @@
       <main>
          <div id='m'></div>
 		 <div id='ex'>
-		   <button id='ex-csv'>Export as CSV</button>
-		   <button id='ex-tsv'>Export as TSV</button>
-		   <button id='ex-geojson'>Export as GeoJSON</button>
+         <button id='ex-tile'>Export as Tile</button>
+         <button id='ex-csv'>Export as CSV</button>
+         <button id='ex-tsv'>Export as TSV</button>
+         <button id='ex-geojson'>Export as GeoJSON</button>
 		 </div>
 		 <div id='stats'></div>
       </main>
@@ -39,6 +40,45 @@
                <div id="load-bar"></div>
                <div id="load-percent">0.00%</div>
                <div id="load-spinner"></div>
+            </div>
+         </div>
+      </div>
+      <div id="tile-modal">
+         <div id="tile-card">
+            <div id="tile-title">Tile export URLs</div>
+            <div id="tile-subtitle">Choose which export URL to copy.</div>
+            
+            <div id="tile-url-list">
+               <div class="tile-url-row">
+                  <div class="tile-url-meta">
+                     <div class="tile-url-label">TMS</div>
+                     <div class="tile-url-desc">Raster tile template</div>
+                  </div>
+                  <pre id="tms-code" class="tile-url-code"></pre>
+                  <button class="tile-copy" data-copy-target="tms-code">Copy</button>
+               </div>
+
+               <div class="tile-url-row">
+                  <div class="tile-url-meta">
+                     <div class="tile-url-label">WMTS</div>
+                     <div class="tile-url-desc">OGC WMTS GetTile template</div>
+                  </div>
+                  <pre id="wmts-code" class="tile-url-code"></pre>
+                  <button class="tile-copy" data-copy-target="wmts-code">Copy</button>
+               </div>
+
+               <div class="tile-url-row">
+                  <div class="tile-url-meta">
+                     <div class="tile-url-label">WFS</div>
+                     <div class="tile-url-desc">OGC WFS GetFeature URL</div>
+                  </div>
+                  <pre id="wfs-code" class="tile-url-code"></pre>
+                  <button class="tile-copy" data-copy-target="wfs-code">Copy</button>
+               </div>
+            </div>
+
+            <div id="tile-actions">
+               <button id="tile-close">Close</button>
             </div>
          </div>
       </div>

--- a/web/script.js
+++ b/web/script.js
@@ -146,8 +146,7 @@ function getWfsExportUrl(feature) {
         service: "WFS",
         version: "2.0.0",
         request: "GetFeature",
-        typeNames: "session_" + sessionId,
-        geomfield: feature.geomfield,
+        typeNames: sessionId + ":" + feature.geomfield,
         outputFormat: "application/json"
     });
     if (feature.id) params.gid = feature.id;
@@ -209,7 +208,7 @@ function showError(err) {
     clearInterval(loadStatusIntervalId);
 }
 
-function loadLayers(id, layers) {
+function loadLayers(sessionId, layers) {
 
     let groups = new Set();
 
@@ -236,7 +235,7 @@ function loadLayers(id, layers) {
         let theme = themes["default"];
         if (layer["group"]) theme = themes[layer["group"]];
 
-        let prepedLayer = getLayer(id, layer);
+        let prepedLayer = getLayer(sessionId, layer);
         if (prepedLayer) {
             prepedLayer.layer = trackTileStyle(prepedLayer.layer, layer);
             prepedLayer.layer.on('load', _onLayerLoad);
@@ -263,12 +262,12 @@ function trackTileStyle(layer, params) {
     return layer;
 }
 
-function getLayer(id, layer) {
+function getLayer(sessionId, layer) {
     return { name: layer["name"], layer: L.nonTiledLayer.wms('heatmap', {
         minZoom: 0,
         maxZoom: 19,
         opacity: 0.9,
-        layers: id,
+        layers: sessionId + ":" + layer["geomfield"],
         styles: [layer["id"]],
         format: 'image/png'
     })};
@@ -350,21 +349,11 @@ function fetchResults() {
             map.on('click', function(e) {
                 const pos = L.Projection.SphericalMercator.project(e.latlng);
 
-                const w = map.getPixelBounds().max.x - map.getPixelBounds().min.x;
-                const h = map.getPixelBounds().max.y - map.getPixelBounds().min.y;
-
-                const sw = L.Projection.SphericalMercator.project((map.getBounds().getSouthWest()));
-                const ne = L.Projection.SphericalMercator.project((map.getBounds().getNorthEast()));
-
-                const bounds = [sw.x, sw.y, ne.x, ne.y];
+                const bounds = [pos.x, pos.y, pos.x, pos.y];
 
                 fetch('wfs?service=WFS&version=2.0.0&request=GetFeature'
-                    + '&id=' + id
-                    + '&x=' + pos.x
-                    + '&y=' + pos.y
+                    + '&typeNames=' + id + ":" + currentTileConfig.geomField
                     + '&rad=' + (100 * Math.pow(2, 14 - map.getZoom()))
-                    + '&width=' + w
-                    + '&height=' + h
                     + '&bbox=' + bounds.join(',')
                     + '&srsName=EPSG:3857'
                     + '&outputFormat=application/json')

--- a/web/script.js
+++ b/web/script.js
@@ -7,6 +7,8 @@ let curGeojson;
 let curGeojsonId = -1;
 let curGeojsonLayer = "";
 
+let currentTileConfig = null;
+
 let urlParams = window.postParams;
 let qleverBackend = urlParams["backend"];
 let query = urlParams["query"];
@@ -57,7 +59,7 @@ function openPopup(data) {
         //
         // NOTE: We assume that the last column contains the geometry information
         // (WKT), which we will not put in the table.
-        let geometry_column = select_variables.length - 1;
+        // let geometry_column = select_variables.length - 1;
         // If the second to last variable exists and is called "?image" or ends in
         // "_image", then show an image with that URL in the first column of the
         // table. Note that we compute the cell contents here and add it during the
@@ -82,7 +84,7 @@ function openPopup(data) {
         select_variables.forEach(function(variable, i) {
             // Skip the last column (WKT literal) and the ?image column (if it
             // exists).
-            if (i == geometry_column ||
+            if (isGeometryVariable(variable) ||
                 variable == "?image" || variable == "?flag" || variable.endsWith("_image")) return;
 
             // Take the variable name as one table column and the result value as
@@ -103,9 +105,9 @@ function openPopup(data) {
                         "<td>" + value + "</td></tr>");
         })
             let popup_html = "<table class=\"popup\">" + popup_content_strings.join("\n") + "</table>";
-            popup_html += '<a class="export-link" href="geojson?gid=' + data[0].id + "&layer=" + data[0].geomfield + "&id=" + sessionId + '&rad=0&export=1">Export as GeoJSON</a>';
-
+            popup_html += '<a class="export-link" href="' + getWfsExportUrl(data[0]) + '">Export via GeoJSON</a>';
             if (curGeojson) curGeojson.remove();
+
 
             L.popup({"maxWidth" : 600})
                 .setLatLng(data[0]["ll"])
@@ -121,6 +123,60 @@ function openPopup(data) {
         curGeojsonLayer = data[0].geomfield;
         curGeojson.addTo(map);
     }
+}
+
+function isGeometryVariable(variable) {
+    return variable == "?geometry" ||
+           variable == "?geom" ||
+           variable == "?wkt" ||
+           variable.endsWith("geometry") ||
+           variable.endsWith("geom") ||
+           variable.endsWith("wkt");
+}
+
+function popupAttributePriority(variable) {
+    if (variable == "?country") return 0;
+    if (variable == "?countryLabel" || variable == "?countryName") return 1;
+    if (variable == "?name" || variable == "?label" || variable == "?placelabel") return 2;
+    return 10;
+}
+
+function getWfsExportUrl(feature) {
+    let params = new URLSearchParams({
+        service: "WFS",
+        version: "2.0.0",
+        request: "GetFeature",
+        typeNames: "session_" + sessionId,
+        geomfield: feature.geomfield,
+        outputFormat: "application/json"
+    });
+    if (feature.id) params.gid = feature.id;
+    return "wfs?" + params.toString();
+}
+
+function wfsFeatureCollectionToPopupData(data) {
+    if (!data || data.type !== "FeatureCollection" || !data.features || data.features.length == 0) {
+        return [];
+    }
+
+    const feature = data.features[0];
+    const props = feature.properties || {};
+
+    const attrs = Object.keys(props)
+        .filter(key => !["id", "gid", "featureID", "geomfield", "popup_lat", "popup_lng"].includes(key))
+        .filter(key => !isGeometryVariable(key))
+        .map(key => [key, String(props[key])])
+        .sort((a, b) => popupAttributePriority(a[0]) - popupAttributePriority(b[0]));
+    return [{
+        id: props.id,
+        geomfield: props.geomfield,
+        attrs: attrs,
+        ll: {
+            lat: parseFloat(props.popup_lat),
+            lng: parseFloat(props.popup_lng)
+        },
+        geom: feature.geometry
+    }];
 }
 
 function getGeoJsonLayer(geom) {
@@ -177,13 +233,12 @@ function loadLayers(id, layers) {
     };
 
     for (layer of layers) {
-        console.log(layer);
-
         let theme = themes["default"];
         if (layer["group"]) theme = themes[layer["group"]];
 
         let prepedLayer = getLayer(id, layer);
         if (prepedLayer) {
+            prepedLayer.layer = trackTileStyle(prepedLayer.layer, layer);
             prepedLayer.layer.on('load', _onLayerLoad);
             if (layer["toggle"] == "checkbox") {
                 theme.overlays[1].layers.push(prepedLayer);
@@ -199,6 +254,13 @@ function loadLayers(id, layers) {
     });
 
     map.addControl(themeControl);
+}
+
+function trackTileStyle(layer, params) {
+    layer.on("add", function() {
+                currentTileConfig = {layerId: params["id"], geomField: params["geomfield"]};
+            });
+    return layer;
 }
 
 function getLayer(id, layer) {
@@ -296,12 +358,21 @@ function fetchResults() {
 
                 const bounds = [sw.x, sw.y, ne.x, ne.y];
 
-                fetch('pos?x=' + pos.x + "&y=" + pos.y + "&id=" + id + "&rad=" + (100 * Math.pow(2, 14 - map.getZoom())) + '&width=' + w + '&height=' + h + '&bbox=' + bounds.join(','))
+                fetch('wfs?service=WFS&version=2.0.0&request=GetFeature'
+                    + '&id=' + id
+                    + '&x=' + pos.x
+                    + '&y=' + pos.y
+                    + '&rad=' + (100 * Math.pow(2, 14 - map.getZoom()))
+                    + '&width=' + w
+                    + '&height=' + h
+                    + '&bbox=' + bounds.join(',')
+                    + '&srsName=EPSG:3857'
+                    + '&outputFormat=application/json')
                     .then(response => {
                         if (!response.ok) return response.text().then(text => {throw new Error(text)});
                         return response.json();
                     })
-                    .then(data => openPopup(data))
+                    .then(data => openPopup(wfsFeatureCollectionToPopupData(data)))
                     .catch(error => showError(error));
             });
 
@@ -355,10 +426,48 @@ function _onLayerLoad(e) {
     document.getElementById("msg").classList.remove("show");
 }
 
+function getVisibleTileLayerId(layerId) {
+    return layerId.replace(/-([?$])/, "-");
+}
+
+function buildTileExportUrls() {
+    if (!sessionId || !currentTileConfig) return null;
+
+    const style = encodeURIComponent(currentTileConfig.style);
+    const wfsTypeName = encodeURIComponent("session_" + sessionId);
+    const layerId = currentTileConfig.layerId;
+
+    const bounds = map.getBounds();
+    const west = bounds.getWest();
+    const south = bounds.getSouth();
+    const east = bounds.getEast();
+    const north = bounds.getNorth();
+    const bbox = encodeURIComponent(`${west},${south},${east},${north}`);
+
+    return {
+        tms: `${window.location.origin}/tms/${sessionId}/${layerId}/{x}/{y}/{z}.png`,
+        wmts: `${window.location.origin}/wmts?service=WMTS&request=GetTile&version=1.0.0&layer=${sessionId}&style=${layerId}&format=image/png&tilematrixset=WebMercatorQuad&tilematrix={z}&tilerow={y}&tilecol={x}`,
+        wfs: `${window.location.origin}/wfs?service=WFS&version=2.0.0&request=GetFeature&typeNames=${wfsTypeName}&layerid=${layerId}&bbox=${bbox}&srsName=EPSG:4326&outputFormat=application/json&count=100`
+    };
+}
+
+function showTileDialog(urls) {
+    document.getElementById("tms-code").textContent = urls.tms;
+    document.getElementById("wmts-code").textContent = urls.wmts;
+    document.getElementById("wfs-code").textContent = urls.wfs;
+    document.getElementById("tile-subtitle").textContent =
+        "Choose which export URL to copy.";
+    document.getElementById("tile-modal").style.display = "flex";
+}
+
+function hideTileDialog() {
+    document.getElementById("tile-modal").style.display = "none";
+}
+
 document.getElementById("ex-geojson").onclick = function() {
     if (!sessionId) return;
     let a = document.createElement("a");
-    a.href = "export?id="+ sessionId;
+    a.href = getWfsExportUrl({geomfield: currentTileConfig.geomField});
     a.setAttribute("download", "export.json");
     a.click();
 }
@@ -376,3 +485,32 @@ document.getElementById("ex-csv").onclick = function() {
     a.setAttribute("download", "export.csv");
     a.click();
 }
+
+document.getElementById("ex-tile").onclick = function() {
+    const urls = buildTileExportUrls();
+    console.log(urls);
+    if (!urls) return;
+    showTileDialog(urls);
+}
+
+document.getElementById("tile-close").onclick = function() {
+    hideTileDialog();
+}
+
+document.querySelectorAll(".tile-copy").forEach(function(button) {
+    button.onclick = async function() {
+        const targetId = button.getAttribute("data-copy-target");
+        const url = document.getElementById(targetId).textContent;
+
+        try {
+            await navigator.clipboard.writeText(url);
+            button.textContent = "Copied";
+            setTimeout(function() {
+                button.textContent = "Copy";
+            }, 1200);
+        } catch (e) {
+            document.getElementById("tile-subtitle").textContent = 
+                "Copy failed - please copy manually.";
+        }
+    };
+});

--- a/web/script.js
+++ b/web/script.js
@@ -153,21 +153,42 @@ function showError(err) {
     clearInterval(loadStatusIntervalId);
 }
 
-function loadLayers(id, numObjects, autoThreshold, layers) {
+function loadLayers(id, layers) {
 
-    let themes = {"custom" : {
-        name: "Layers",
-        overlays: [{name:"", type:"radio", layers: []}, {name:"", type:"checkbox", layers: []}]
-    }};
+    let groups = new Set();
 
     for (layer of layers) {
-        let prepedLayer = getLayer(id, layer, autoThreshold);
+        if (layer["group"]) groups.add(layer["group"]);
+    }
+
+    let themes = {};
+
+    if (groups.size) {
+        for (group of groups) {
+            themes[group] = {
+                name: group,
+                overlays: [{name:"", type:"radio", layers: []}, {name:"", type:"checkbox", layers: []}]
+            }
+        }
+    }
+    themes["default"] = {
+        name: "Layers",
+        overlays: [{name:"", type:"radio", layers: []}, {name:"", type:"checkbox", layers: []}]
+    };
+
+    for (layer of layers) {
+        console.log(layer);
+
+        let theme = themes["default"];
+        if (layer["group"]) theme = themes[layer["group"]];
+
+        let prepedLayer = getLayer(id, layer);
         if (prepedLayer) {
             prepedLayer.layer.on('load', _onLayerLoad);
             if (layer["toggle"] == "checkbox") {
-                themes["custom"].overlays[1].layers.push(prepedLayer);
+                theme.overlays[1].layers.push(prepedLayer);
             } else {
-                themes["custom"].overlays[0].layers.push(prepedLayer);
+                theme.overlays[0].layers.push(prepedLayer);
             }
         }
     }
@@ -178,63 +199,17 @@ function loadLayers(id, numObjects, autoThreshold, layers) {
     });
 
     map.addControl(themeControl);
-
-    if (themes["custom"].overlays[0].layers.length > 0 || themes["custom"].overlays[1].layers.length > 0) themeControl.applyTheme("custom");
-    else _onLayerLoad();
 }
 
-function getLayer(id, layer, autoThreshold) {
-    if (layer["style"] == "auto") {
-        const autoHeatmapLayer = L.nonTiledLayer.wms('heatmap', {
-            minZoom: 0,
-            maxZoom: 15,
-            opacity: layer["numobjects"] > autoThreshold ? 0.8 : 0.9,
-            layers: id + "-" + layer["geomfield"],
-            styles: layer["numobjects"] > autoThreshold ? ["heatmap-" + layer["colorscheme"]] : ["objects-" + layer["color"]],
-            format: 'image/png',
-            transparent: true,
-        });
-
-        const autoObjectLayer = L.nonTiledLayer.wms('heatmap', {
-            minZoom: 16,
-            maxZoom: 19,
-            opacity: 0.9,
-            layers: id + "-" + layer["geomfield"],
-            styles: ["objects-" + layer["color"]],
-            format: 'image/png'
-        });
-
-        return  { name: layer["name"], layer: L.layerGroup([autoHeatmapLayer, autoObjectLayer])};
-    } else if (layer["style"] == "raster") {
-        return  { name: layer["name"], layer: L.nonTiledLayer.wms('heatmap', {
-            minZoom: 0,
-            maxZoom: 19,
-            opacity: 0.8,
-            layers: id + "-" + layer["geomfield"],
-            styles: ["raster-" + layer["rasterw"] + "x" + layer["rasterh"] + "-" +  layer["colorscheme"]],
-            format: 'image/png',
-            transparent: true
-        })};
-    } else if (layer["style"] == "heatmap") {
-        return { name: layer["name"], layer: L.nonTiledLayer.wms('heatmap', {
-            minZoom: 0,
-            maxZoom: 19,
-            opacity: 0.8,
-            layers: id + "-" + layer["geomfield"],
-            styles: ["heatmap-" + layer["colorscheme"]],
-            format: 'image/png',
-            transparent: true
-        }) };
-    } else {
-        return { name: layer["name"], layer: L.nonTiledLayer.wms('heatmap', {
-            minZoom: 0,
-            maxZoom: 19,
-            opacity: 0.9,
-            layers: id + "-" + layer["geomfield"],
-            styles: ["objects-" + layer["color"]],
-            format: 'image/png'
-        })};
-    }
+function getLayer(id, layer) {
+    return { name: layer["name"], layer: L.nonTiledLayer.wms('heatmap', {
+        minZoom: 0,
+        maxZoom: 19,
+        opacity: 0.9,
+        layers: id,
+        styles: [layer["id"]],
+        format: 'image/png'
+    })};
 
     return null;
 }
@@ -304,10 +279,8 @@ function fetchResults() {
             if (data["layers"].length == 0) {
                 showError("No layers specified in config");
                 clearInterval(loadStatusIntervalId);
-            } else if (data["layers"].length == 1 && data["layers"][0].style == "auto") {
-                loadSimpleMap(data["qid"], data["numobjects"], data["autothreshold"], data["layers"][0]);
             } else {
-                loadLayers(data["qid"], data["numobjects"], data["autothreshold"], data["layers"]);
+                loadLayers(data["qid"], data["layers"]);
             }
 
             let id = data["qid"];
@@ -346,107 +319,6 @@ function fetchResults() {
             });
         })
         .catch(error => showError(error));
-}
-
-function loadSimpleMap(id, numObjects, autoThreshold, layer) {
-    const heatmapStyles = ["spectralexp", "spectral", "RdYlGn", "RdYlGnexp", "RdYlBu","RdYlBuexp", "w2b", "b2w", "RdGy","RdGyexp","YlOrRd","YlOrRdexp","Blues","Bluesexp","Greens","Greensexp","Greys","Greysexp","Oranges","Orangesexp","Reds", "Redsexp"];
-    let heatmapLayers = [];
-
-    for (const s of heatmapStyles) {
-        heatmapLayers.push({
-            name: s,
-            layer: L.nonTiledLayer.wms('heatmap', {
-                minZoom: 0,
-                maxZoom: 19,
-                opacity: 0.8,
-                layers: id + "-" + layer["geomfield"],
-                styles: ["heatmap-" + s],
-                format: 'image/png',
-                transparent: true,
-            })
-        });
-        heatmapLayers[heatmapLayers.length - 1].layer.on('load', _onLayerLoad);
-    }
-
-    const objectsLayer = L.nonTiledLayer.wms('heatmap', {
-        minZoom: 0,
-        maxZoom: 19,
-        opacity: 0.9,
-        layers: id + "-" + layer["geomfield"],
-        styles: ["objects-" + layer["color"]],
-        format: 'image/png'
-    });
-
-    const autoHeatmapLayer = L.nonTiledLayer.wms('heatmap', {
-        minZoom: 0,
-        maxZoom: 15,
-        opacity: numObjects > autoThreshold ? 0.8 : 0.9,
-        layers: id + "-" + layer["geomfield"],
-        styles: numObjects > autoThreshold ? ["heatmap-spectralexp"] : ["objects-" + layer["color"]],
-        format: 'image/png',
-        transparent: true,
-    });
-
-    const autoObjectLayer = L.nonTiledLayer.wms('heatmap', {
-        minZoom: 16,
-        maxZoom: 19,
-        opacity: 0.9,
-        layers: id + "-" + layer["geomfield"],
-        styles: ["objects-" + layer["color"]],
-        format: 'image/png'
-    });
-    const autoLayerGroup = L.layerGroup([autoHeatmapLayer, autoObjectLayer]);
-
-    objectsLayer.on('load', _onLayerLoad);
-    autoHeatmapLayer.on('load', _onLayerLoad);
-    autoObjectLayer.on('load', _onLayerLoad);
-
-    const themes = {
-        auto: {
-            name: "Auto",
-            overlays: [
-                {
-                    name: "Style",
-                    type: "radio",
-                    layers: [
-                        { name: "Default", layer: autoLayerGroup },
-                    ]
-                }
-            ]
-        },
-
-        heatmap: {
-            name: "Heatmap",
-            overlays: [
-                {
-                    name: "Style",
-                    type: "radio",
-                    layers: heatmapLayers
-                }
-            ]
-        },
-
-        objects: {
-            name: "Objects",
-            overlays: [
-                {
-                    name: "Layers",
-                    type: "checkbox",
-                    layers: [
-                        { name: "default", layer: objectsLayer },
-                    ]
-                }
-            ]
-        }
-    };
-
-    const themeControl = new L.Control.ThemeLayerSwitcher(themes, {
-        position: 'topleft',
-        defaultTheme: 'auto',
-    });
-
-    map.addControl(themeControl);
-    themeControl.applyTheme(mode);
 }
 
 function fetchLoadStatusInterval(interval) {

--- a/web/style.css
+++ b/web/style.css
@@ -796,15 +796,15 @@ h1, #msg-heading {
 	display: none;
 }
 
-.leaflet-control-layers .leaflet-control-layers-overlays:has(> :nth-child(3)) {
+.leaflet-control-layers .leaflet-control-layers-overlays:has(> :nth-child(2)) {
 	display: block;
-   margin-top:20px;
 }
 
 .leaflet-control-layers .leaflet-control-layers-separator {
   margin: 0;
   position: relative;
   top: 10px;
+  margin-bottom: 20px;
 }
 
 .export-link {

--- a/web/style.css
+++ b/web/style.css
@@ -88,7 +88,8 @@
 }
 
 .leaflet-overlay-pane {
-    z-index: 400
+    z-index: 400;
+    transform: translate3d(-0.5px, -0.5px, 0);
 }
 
 .leaflet-shadow-pane {

--- a/web/style.css
+++ b/web/style.css
@@ -766,7 +766,9 @@ h1, #msg-heading {
     padding: 5px;
 }
 
-#ex button {
+#ex button,
+#tile-actions button,
+.tile-copy {
     padding: 6px 12px;
     margin-bottom: 0;
     font-size: 15px;
@@ -789,7 +791,9 @@ h1, #msg-heading {
     box-shadow: 4px 4px 9px -6px #000000;
 }
 
-#ex button:hover {
+#ex button:hover,
+#tile-actions button:hover,
+.tile-copy:hover {
     background-color: #f4f4f4;
 }
 
@@ -810,4 +814,80 @@ h1, #msg-heading {
 
 .export-link {
     font-size: 80%;
+}
+
+#tile-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.55);
+    z-index: 2000;
+}
+
+#tile-card {
+    width: min(760px, 92vw);
+    background: #fff;
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.12);
+}
+
+#tile-title {
+    font-size: 24px;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+#tile-subtitle {
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 16px;
+}
+
+#tile-url-list {
+    border-top: 1px solid #ddd;
+    margin-bottom: 18px;
+}
+
+.tile-url-row {
+    display: grid;
+    grid-template-columns: 120px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    border-bottom: 1px solid #ddd;
+    padding: 12px 0;
+}
+
+.tile-url-meta {
+    min-width: 0;
+}
+
+.tile-url-label {
+    font-weight: 700;
+}
+.tile-url-desc {
+    color: #666;
+    font-size: 13px;
+}
+.tile-url-code {
+    background: #f5f5f5;
+    border-radius: 6px;
+    padding: 10px 12px;
+    font-family: monospace;
+    font-size: 13px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: 0;
+    min-width: 0;
+}
+
+.tile-copy {
+    margin-left: 0;
+}
+#tile-actions {
+    display: flex;
+    gap: 12px;
 }

--- a/web/themelayer.js
+++ b/web/themelayer.js
@@ -16,6 +16,11 @@ L.Control.ThemeLayerSwitcher = L.Control.extend({
   onAdd: function (map) {
     this._map = map;
 
+    // themes without any layer are not shown at all
+    this._themeKeys = Object.keys(this.themes).filter(
+      key => this._nonEmptyGroups(this.themes[key]).length
+    );
+
     const container = this._container = L.DomUtil.create(
       'div',
       'leaflet-control-layers'
@@ -39,17 +44,22 @@ L.Control.ThemeLayerSwitcher = L.Control.extend({
       container
     );
 
-    this._baseList = L.DomUtil.create(
-      'div',
-      'leaflet-control-layers-base',
-      this._form
-    );
+    // with a single theme, there is nothing to choose from
+    if (this._themeKeys.length > 1) {
+      this._baseList = L.DomUtil.create(
+        'div',
+        'leaflet-control-layers-base',
+        this._form
+      );
 
-    L.DomUtil.create(
-      'div',
-      'leaflet-control-layers-separator',
-      this._form
-    );
+      L.DomUtil.create(
+        'div',
+        'leaflet-control-layers-separator',
+        this._form
+      );
+
+      this._createThemeRadios();
+    }
 
     this._overlayList = L.DomUtil.create(
       'div',
@@ -57,11 +67,18 @@ L.Control.ThemeLayerSwitcher = L.Control.extend({
       this._form
     );
 
-    this._createThemeRadios();
-
     const initial =
-      this.options.defaultTheme || Object.keys(this.themes)[0];
-    this.applyTheme(initial);
+      this._themeKeys.indexOf(this.options.defaultTheme) > -1
+        ? this.options.defaultTheme
+        : this._themeKeys[0];
+    if (initial) this.applyTheme(initial);
+
+    // with only a single layer overall, there is nothing to switch at all, the
+    // layer itself was already added to the map by applyTheme
+    if (this._allLayers().size < 2) {
+      container.style.display = 'none';
+      return container;
+    }
 
     if (!this.options.collapsed) {
       this._expand();
@@ -101,8 +118,27 @@ L.Control.ThemeLayerSwitcher = L.Control.extend({
 
   /* ---------------- THEMES ---------------- */
 
-  _createThemeRadios: function () {
+  // the overlay groups of a theme which contain at least one layer
+  _nonEmptyGroups: function (theme) {
+    if (!theme) return [];
+    return (theme.overlays || []).filter(
+      group => group.layers && group.layers.length
+    );
+  },
+
+  // all distinct layers over all themes
+  _allLayers: function () {
+    const layers = new Set();
     Object.keys(this.themes).forEach(key => {
+      this._nonEmptyGroups(this.themes[key]).forEach(group => {
+        group.layers.forEach(entry => layers.add(entry.layer));
+      });
+    });
+    return layers;
+  },
+
+  _createThemeRadios: function () {
+    this._themeKeys.forEach(key => {
       const label = L.DomUtil.create('label', '', this._baseList);
       const input = L.DomUtil.create('input', '', label);
 
@@ -131,8 +167,12 @@ L.Control.ThemeLayerSwitcher = L.Control.extend({
 
 
     this._overlayList.innerHTML = '';
-    (theme.overlays || []).forEach(group => {
-      this._buildOverlayGroup(group, themeKey);
+
+    // empty overlay groups are not shown, and if only a single group is left,
+    // there is no need to name it
+    const groups = this._nonEmptyGroups(theme);
+    groups.forEach(group => {
+      this._buildOverlayGroup(group, themeKey, groups.length > 1);
     });
 
     this._activeTheme = themeKey;
@@ -140,6 +180,7 @@ L.Control.ThemeLayerSwitcher = L.Control.extend({
   },
 
   _syncThemeUI: function () {
+    if (!this._baseList) return;
     const radios = this._baseList.querySelectorAll('input');
     radios.forEach(radio => {
       radio.checked = radio.value === this._activeTheme;
@@ -148,13 +189,15 @@ L.Control.ThemeLayerSwitcher = L.Control.extend({
 
   /* ---------------- OVERLAYS ---------------- */
 
-  _buildOverlayGroup: function (group, themeKey) {
-    const header = L.DomUtil.create(
-      'div',
-      'leaflet-control-layers-group',
-      this._overlayList
-    );
-    header.innerHTML = `<strong>${group.name}</strong>`;
+  _buildOverlayGroup: function (group, themeKey, showHeader) {
+    if (showHeader) {
+      const header = L.DomUtil.create(
+        'div',
+        'leaflet-control-layers-group',
+        this._overlayList
+      );
+      header.innerHTML = `<strong>${group.name}</strong>`;
+    }
 
 	let have = false;
 


### PR DESCRIPTION
Adds the following styling options to layers:

`linew` to specify the (out)line width in pixels
`fillopacity` to specify the opacity which with polygons are filled
`lineopacity` to specify the opacity with which (out)lines are drawn
`pointradius` to specify the point radius.

Each layer now can get its own style. To efficiently support various styles over the same geometry column, this PR also removes double geometry column bookkeeping. Previously, a "layer" was uniquely defined by its geometry column, and multiple layers using the same column were hackily implemented by using suffixed geometry columns, with additional code to extract the "real" internal geometry column. This lead to the same geometry column to be loaded and stored for each layer, which is now no longer the case.

On the side, improve the usage of the various new WFS capabilities, drop all legacy endpoints (and their usage in the web client), fix a few minor web client issues regarding multiple layers, and add the option `enabled` for `toggle=checkbox` layers to specify whether it is enabled at start (the default) or not.