### PR TITLE
Adjust geometry parsing to new projection signature in util

### DIFF
--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -85,13 +85,14 @@ void GeomCache::parse(const char *c, size_t size) {
             _qidToIdFSize++;
           } else {
             const char *s = 0;
-            auto wktType = util::geo::getWKTType(_dangling.c_str(), &s);
+            auto crsType = util::geo::getCRSType(_dangling.c_str(), &s)
+            auto wktType = util::geo::getWKTType(s, &s);
             size_t i = 0;
 
             if (wktType == util::geo::WKTType::COLLECTION) {
               _curUniqueGeom++;
               const auto &coll =
-                  util::geo::collectionFromWKTProj<double>(s, 0, &projD);
+                  util::geo::collectionFromWKTProj<double>(s, 0, &projD, crsType);
 
               for (const auto &g : coll) {
                 if (g.getType() == 0) addMultiPoint({g.getPoint()}, &i);
@@ -103,27 +104,27 @@ void GeomCache::parse(const char *c, size_t size) {
               }
             } else if (wktType == util::geo::WKTType::MULTIPOINT) {
               _curUniqueGeom++;
-              const auto &mp = multiPointFromWKTProj<double>(s, 0, &projD);
+              const auto &mp = multiPointFromWKTProj<double>(s, 0, &projD, crsType);
               addMultiPoint(mp, &i);
             } else if (wktType == util::geo::WKTType::POINT) {
               _curUniqueGeom++;
-              const auto &mp = multiPointFromWKTProj<double>(s, 0, &projD);
+              const auto &mp = multiPointFromWKTProj<double>(s, 0, &projD, crsType);
               addMultiPoint(mp, &i);
             } else if (wktType == util::geo::WKTType::MULTILINESTRING) {
               _curUniqueGeom++;
-              const auto &ml = multiLineFromWKTProj<double>(s, 0, &projD);
+              const auto &ml = multiLineFromWKTProj<double>(s, 0, &projD, crsType);
               addMultiLineString(ml, &i);
             } else if (wktType == util::geo::WKTType::LINESTRING) {
               _curUniqueGeom++;
-              const auto &l = lineFromWKTProj<double>(s, 0, &projD);
+              const auto &l = lineFromWKTProj<double>(s, 0, &projD, crsType);
               addLineString(l, &i);
             } else if (wktType == util::geo::WKTType::MULTIPOLYGON) {
               _curUniqueGeom++;
-              const auto &mp = multiPolygonFromWKTProj<double>(s, 0, &projD);
+              const auto &mp = multiPolygonFromWKTProj<double>(s, 0, &projD, crsType);
               addMultiPolygon(mp, &i);
             } else if (wktType == util::geo::WKTType::POLYGON) {
               _curUniqueGeom++;
-              const auto &poly = polygonFromWKTProj<double>(s, 0, &projD);
+              const auto &poly = polygonFromWKTProj<double>(s, 0, &projD, crsType);
               addPolygon(poly, &i);
             }
 

--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -89,43 +89,45 @@ void GeomCache::parse(const char *c, size_t size) {
             auto wktType = util::geo::getWKTType(s, &s);
             size_t i = 0;
 
-            if (wktType == util::geo::WKTType::COLLECTION) {
-              _curUniqueGeom++;
-              const auto &coll =
-                  util::geo::collectionFromWKTProj<double>(s, 0, &projD, crsType);
+            if (crsType != util::geo::CRSType::UNSUPPORTED) {
+              if (wktType == util::geo::WKTType::COLLECTION) {
+                _curUniqueGeom++;
+                const auto &coll =
+                    util::geo::collectionFromWKTProj<double>(s, 0, &projD, crsType);
 
-              for (const auto &g : coll) {
-                if (g.getType() == 0) addMultiPoint({g.getPoint()}, &i);
-                if (g.getType() == 1) addLineString(g.getLine(), &i);
-                if (g.getType() == 2) addPolygon(g.getPolygon(), &i);
-                if (g.getType() == 3) addMultiLineString(g.getMultiLine(), &i);
-                if (g.getType() == 4) addMultiPolygon(g.getMultiPolygon(), &i);
-                if (g.getType() == 6) addMultiPoint(g.getMultiPoint(), &i);
+                for (const auto &g : coll) {
+                  if (g.getType() == 0) addMultiPoint({g.getPoint()}, &i);
+                  if (g.getType() == 1) addLineString(g.getLine(), &i);
+                  if (g.getType() == 2) addPolygon(g.getPolygon(), &i);
+                  if (g.getType() == 3) addMultiLineString(g.getMultiLine(), &i);
+                  if (g.getType() == 4) addMultiPolygon(g.getMultiPolygon(), &i);
+                  if (g.getType() == 6) addMultiPoint(g.getMultiPoint(), &i);
+                }
+              } else if (wktType == util::geo::WKTType::MULTIPOINT) {
+                _curUniqueGeom++;
+                const auto &mp = multiPointFromWKTProj<double>(s, 0, &projD, crsType);
+                addMultiPoint(mp, &i);
+              } else if (wktType == util::geo::WKTType::POINT) {
+                _curUniqueGeom++;
+                const auto &mp = multiPointFromWKTProj<double>(s, 0, &projD, crsType);
+                addMultiPoint(mp, &i);
+              } else if (wktType == util::geo::WKTType::MULTILINESTRING) {
+                _curUniqueGeom++;
+                const auto &ml = multiLineFromWKTProj<double>(s, 0, &projD, crsType);
+                addMultiLineString(ml, &i);
+              } else if (wktType == util::geo::WKTType::LINESTRING) {
+                _curUniqueGeom++;
+                const auto &l = lineFromWKTProj<double>(s, 0, &projD, crsType);
+                addLineString(l, &i);
+              } else if (wktType == util::geo::WKTType::MULTIPOLYGON) {
+                _curUniqueGeom++;
+                const auto &mp = multiPolygonFromWKTProj<double>(s, 0, &projD, crsType);
+                addMultiPolygon(mp, &i);
+              } else if (wktType == util::geo::WKTType::POLYGON) {
+                _curUniqueGeom++;
+                const auto &poly = polygonFromWKTProj<double>(s, 0, &projD, crsType);
+                addPolygon(poly, &i);
               }
-            } else if (wktType == util::geo::WKTType::MULTIPOINT) {
-              _curUniqueGeom++;
-              const auto &mp = multiPointFromWKTProj<double>(s, 0, &projD, crsType);
-              addMultiPoint(mp, &i);
-            } else if (wktType == util::geo::WKTType::POINT) {
-              _curUniqueGeom++;
-              const auto &mp = multiPointFromWKTProj<double>(s, 0, &projD, crsType);
-              addMultiPoint(mp, &i);
-            } else if (wktType == util::geo::WKTType::MULTILINESTRING) {
-              _curUniqueGeom++;
-              const auto &ml = multiLineFromWKTProj<double>(s, 0, &projD, crsType);
-              addMultiLineString(ml, &i);
-            } else if (wktType == util::geo::WKTType::LINESTRING) {
-              _curUniqueGeom++;
-              const auto &l = lineFromWKTProj<double>(s, 0, &projD, crsType);
-              addLineString(l, &i);
-            } else if (wktType == util::geo::WKTType::MULTIPOLYGON) {
-              _curUniqueGeom++;
-              const auto &mp = multiPolygonFromWKTProj<double>(s, 0, &projD, crsType);
-              addMultiPolygon(mp, &i);
-            } else if (wktType == util::geo::WKTType::POLYGON) {
-              _curUniqueGeom++;
-              const auto &poly = polygonFromWKTProj<double>(s, 0, &projD, crsType);
-              addPolygon(poly, &i);
             }
 
             // dummy element to keep sync

--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -85,7 +85,7 @@ void GeomCache::parse(const char *c, size_t size) {
             _qidToIdFSize++;
           } else {
             const char *s = 0;
-            auto crsType = util::geo::getCRSType(_dangling.c_str(), &s)
+            auto crsType = util::geo::getCRSType(_dangling.c_str(), &s);
             auto wktType = util::geo::getWKTType(s, &s);
             size_t i = 0;
 

--- a/src/qlever-petrimaps/GeomCache.h
+++ b/src/qlever-petrimaps/GeomCache.h
@@ -221,8 +221,8 @@ class GeomCache {
 
   static std::vector<size_t> getGeomStarts(const std::string& str, size_t a);
 
-  static util::geo::DPoint projD(const util::geo::DPoint& p) {
-    return util::geo::latLngToWebMerc<double>(p);
+  static util::geo::DPoint projD(const util::geo::DPoint& p, util::geo::CRSType sourceCRS) {
+    return util::geo::projectToWebMerc<double>(p, sourceCRS);
   }
 
   std::vector<util::geo::FPoint, util::no_init_allocator<util::geo::FPoint>>


### PR DESCRIPTION
This adds a `sourceCRS` argument to the used `projFunc`, as required by the new projection function signature from [util CRS PR](https://github.com/ad-freiburg/util/pull/5). This will only work in combination with the changes from the linked PR.