### PR TITLE
Ask the backend which datatype value it uses for points

### DIFF
--- a/src/qlever-petrimaps/GeomCache.cpp
+++ b/src/qlever-petrimaps/GeomCache.cpp
@@ -1100,6 +1100,13 @@ std::string GeomCache::requestIndexHash() {
 }
 
 // _____________________________________________________________________________
+uint8_t GeomCache::requestGeoPointDatatype() {
+  auto r = RequestReader(getConfig().backend, _maxMemory, 0, 0, 0);
+
+  return r.requestGeoPointDatatype();
+}
+
+// _____________________________________________________________________________
 std::pair<double, double> GeomCache::getRasterMeta(size_t did) const {
   auto i = _rasterMeta.find(did);
   if (i != _rasterMeta.end()) return i->second;
@@ -1123,6 +1130,10 @@ std::string GeomCache::load(const std::string &cacheDir) {
               << ") and remote index hash (" << indexHash << ") dont match.";
     _ready = false;
   }
+
+  // Only ask for this when the cache is built or rebuilt, not for every query.
+  _geoPointDatatype = requestGeoPointDatatype();
+  LOG(INFO) << "Datatype of a point is " << static_cast<int>(_geoPointDatatype);
 
   if (cacheDir.size()) {
     std::string backend = getConfig().backend;

--- a/src/qlever-petrimaps/GeomCache.h
+++ b/src/qlever-petrimaps/GeomCache.h
@@ -135,6 +135,10 @@ class GeomCache {
 
   const GeomCacheConfig& getConfig() const { return _config; }
 
+  // The datatype value this backend uses for points, see
+  // `RequestReader::requestGeoPointDatatype`.
+  uint8_t getGeoPointDatatype() const { return _geoPointDatatype; }
+
   const std::vector<util::geo::FPoint,
                     util::no_init_allocator<util::geo::FPoint>>&
   getPoints() const {
@@ -205,6 +209,8 @@ class GeomCache {
 
   std::string requestIndexHash();
 
+  uint8_t requestGeoPointDatatype();
+
   void requestRasterMeta();
 
   std::string queryFields(std::string query, size_t offset, size_t limit) const;
@@ -262,6 +268,8 @@ class GeomCache {
   bool _ready = false;
 
   std::string _indexHash;
+
+  uint8_t _geoPointDatatype = DEFAULT_GEOPOINT_DATATYPE;
 };
 }  // namespace petrimaps
 

--- a/src/qlever-petrimaps/Misc.cpp
+++ b/src/qlever-petrimaps/Misc.cpp
@@ -208,7 +208,7 @@ void RequestReader::parseRasterMeta(const char* c, size_t size) {
     _curIdCol = _curIdCol % 3;
 
     if (_curByte == 0) {
-      uint8_t type = (_curId.val & (uint64_t(15) << 60)) >> 60;
+      uint8_t type = idDatatype(_curId.val);
 
       if (_curIdCol == 0) {
         // raster dataset it
@@ -270,7 +270,7 @@ void RequestReader::parseIds(const char* c, size_t size) {
       } else if (_curIdCol < _valFields + _geomFields) {
         // value
 
-        uint8_t type = (_curId.val & (uint64_t(15) << 60)) >> 60;
+        uint8_t type = idDatatype(_curId.val);
         if (type == 3) {
           // 3 = double in qlever
           uint64_t rawBits = (_curId.val << 4);
@@ -479,4 +479,39 @@ std::string RequestReader::requestIndexHash(const std::string& configHash) {
   }
 
   return INDEX_HASH_PREFIX + "|" + configHash + "|" + response;
+}
+
+// _____________________________________________________________________________
+uint8_t RequestReader::requestGeoPointDatatype() {
+  // The datatype value for a point is not fixed, it changes whenever a
+  // datatype is added to QLever before it. Let the backend return a single
+  // point and read the value from the top four bits of its ID.
+  const static std::string query =
+      "PREFIX geo: <http://www.opengis.net/ont/geosparql#> "
+      "SELECT ?point WHERE { BIND(\"POINT(0 0)\"^^geo:wktLiteral AS ?point) }";
+
+  std::string response;
+
+  try {
+    performCurlRequest(
+        _backendUrl, queryFields(query), "application/octet-stream", "",
+        [&response](const char* c, size_t n) { response.append(c, n); },
+        nullptr);
+  } catch (const std::exception& e) {
+    LOG(WARN) << "[GEOMCACHE] Could not obtain the datatype of a point: "
+              << e.what();
+    return DEFAULT_GEOPOINT_DATATYPE;
+  }
+
+  // The answer is a single ID, in the byte order it was written in.
+  if (response.size() != sizeof(ID)) {
+    LOG(WARN) << "[GEOMCACHE] Unexpected answer of size " << response.size()
+              << " when asking for the datatype of a point";
+    return DEFAULT_GEOPOINT_DATATYPE;
+  }
+
+  ID id;
+  memcpy(id.bytes, response.data(), sizeof(id.bytes));
+
+  return idDatatype(id.val);
 }

--- a/src/qlever-petrimaps/Misc.h
+++ b/src/qlever-petrimaps/Misc.h
@@ -49,6 +49,15 @@ union ID {
   uint8_t bytes[8];
 };
 
+// The datatype of a QLever ID is stored in its top four bits.
+inline uint8_t idDatatype(uint64_t id) {
+  return (id & (uint64_t(15) << 60)) >> 60;
+}
+
+// The datatype value for a point, used when a backend cannot be asked for it,
+// see `RequestReader::requestGeoPointDatatype`.
+const static uint8_t DEFAULT_GEOPOINT_DATATYPE = 9;
+
 inline bool operator<(const IdMapping& lh, const IdMapping& rh) {
   if (lh.qid < rh.qid) return true;
   return false;
@@ -196,6 +205,7 @@ struct RequestReader {
   std::map<size_t, std::pair<double, double>> requestRasterMeta(
       const std::string& query, const std::string& remoteAddr);
   std::string requestIndexHash(const std::string& configHash);
+  uint8_t requestGeoPointDatatype();
   void requestRows(const std::string& qurl, const std::string& remoteAddr);
   void requestRows(const std::string& query,
                    const std::function<void(const char*, size_t)>& parse,

--- a/src/qlever-petrimaps/server/Requestor.cpp
+++ b/src/qlever-petrimaps/server/Requestor.cpp
@@ -988,17 +988,18 @@ std::vector<std::pair<util::geo::FPoint, ID_TYPE>> Requestor::getDynamicPoints(
 
   size_t count = 0;
 
+  // Points are not in the geometry cache, they are encoded in the ID itself.
+  uint8_t pointDatatype = _cache->getGeoPointDatatype();
+
   for (const auto& p : ids) {
-    uint8_t type = (p.qid & (uint64_t(15) << 60)) >> 60;
-    if (type == 8) count++;  // 8 = Geopoint in Qlever
+    if (idDatatype(p.qid) == pointDatatype) count++;
   }
 
   checkMem(sizeof(std::pair<util::geo::FPoint, ID_TYPE>) * count, _maxMemory);
   ret.reserve(count);
 
   for (const auto& p : ids) {
-    uint8_t type = (p.qid & (uint64_t(15) << 60)) >> 60;
-    if (type != 8) continue;  // 8 = Geopoint in Qlever
+    if (idDatatype(p.qid) != pointDatatype) continue;
 
     uint64_t maskLng = 1073741823;
     uint64_t maskLat = static_cast<uint64_t>(1073741823) << 30;


### PR DESCRIPTION
Points are not stored in the geometry cache, they are encoded in the ID itself and recognized by the datatype in its top four bits. That value was hardcoded as 8 in `getDynamicPoints`, but it is not the same for all backends. QLever added a datatype before the one for points, so a current server uses 9. Against such a backend every point is skipped, and a query that returns only points gives an empty map with no bounds, which the client renders as a maximally zoomed out empty world.

The value is now read from the backend instead, once per cache load, by letting it return a single point and looking at the top four bits of that ID. One build thereby works with backends of both generations, which matters while servers are being upgraded one by one, and it keeps working the next time a datatype is added. If a backend cannot be asked, the current value is assumed.

Tested with one binary against a backend of each generation, using a query that returns only points. Before the change the newer backend gives 0 objects and the older one works, after it both return all their points with correct coordinates.