### PR TITLE
Fix the loading box and the checkbox layers of multi-layer maps, add a per-layer `pointsize`

### DIFF
--- a/src/qlever-petrimaps/server/RenderContext.cpp
+++ b/src/qlever-petrimaps/server/RenderContext.cpp
@@ -112,8 +112,12 @@ void RenderContext::drawPoint(size_t tid, int px, int py, double weight,
       }
     }
   } else if (_style == OBJECTS) {
+    // a disc of radius r; the + r keeps the outline round at small radii
+    // while still filling the full 3x3 square for r = 1
     for (int x = px - r; x <= px + r; x++) {
       for (int y = py - r; y <= py + r; y++) {
+        int dx = x - px, dy = y - py;
+        if (dx * dx + dy * dy > r * r + r) continue;
         if (x >= 0 && y >= 0 && x < _w && y < _h) {
           if (_weights[tid][_w * y + x] == 0)
             _points[tid].push_back(_w * y + x);

--- a/src/qlever-petrimaps/server/Requestor.h
+++ b/src/qlever-petrimaps/server/Requestor.h
@@ -33,6 +33,8 @@ struct FieldConfig {
   std::string color = "3388ff";
   std::string colorscheme = "spectralexp";
   std::string style = "auto";
+  // radius in pixels of a point in the objects style; 1 draws a 3x3 square
+  int pointSize = 1;
 
   const std::string geomFieldRaw() const {
     return util::split(geomField, ':')[0];

--- a/src/qlever-petrimaps/server/Server.cpp
+++ b/src/qlever-petrimaps/server/Server.cpp
@@ -348,6 +348,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
   double res = mercH / h;
   size_t fid = r->getFieldId(field);
+  const int pointR = r->getFields()[fid].pointSize;
 
   checkMem(sizeof(float) * w * h, _maxMemory);
   double realCellSize = r->getPointGrid(fid).getCellWidth();
@@ -390,7 +391,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
           auto ppx = RenderContext::mercToPx(p, orx, ory, mercW, mercH, w, h);
 
           rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(fid, oid), 0, 0,
-                             1);
+                             pointR);
           rcontext.drawLineSegment(px.getX(), px.getY(), ppx.getX(), ppx.getY(),
                                    w, h);
         } else {
@@ -408,7 +409,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
                                rasterMeta.first, rasterMeta.second, 1);
           } else {
             rcontext.drawPoint(0, px.getX(), px.getY(), r->getVal(fid, oid), 0,
-                               0, 1);
+                                0, pointR);
           }
         }
       }
@@ -435,7 +436,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
 
             // TODO: just setting rasterWidth to 1x1 here is not correct
             rcontext.drawPoint(tid, px.getX(), px.getY(), grid.getCellSum(x, y),
-                               1, 1, 1);
+                               1, 1, pointR);
           } else {
             for (auto oid : *cell) {
               if (r->isCluster(fid, oid)) oid = r->getCluster(fid, oid).first;
@@ -452,7 +453,7 @@ util::http::Answer Server::handleHeatMapReq(const Params& pars,
                                    rasterMeta.second, 1);
               } else {
                 rcontext.drawPoint(tid, px.getX(), px.getY(),
-                                   r->getVal(fid, oid), 0, 0, 1);
+                                   r->getVal(fid, oid), 0, 0, pointR);
               }
             }
           }
@@ -2230,6 +2231,7 @@ util::http::Answer Server::handleQueryReq(const Params& pars,
     json << "\"numobjects\":\""
          << reqor->getNumObjects(reqor->getFieldId(fld.geomField)) << "\",";
     json << "\"style\":\"" << fld.style << "\",";
+    json << "\"pointsize\":" << fld.pointSize << ",";
     json << "\"toggle\":\"" << fld.toggle << "\"";
     if (fld.rasterW != 0 && fld.rasterH != 0)
       json << ",\"rasterw\":" << fld.rasterW << ", \"rasterh\":" << fld.rasterH;
@@ -2713,6 +2715,9 @@ RequestorConfig Server::getRequestorCfgFromJSON(
                   layer.value()["colorscheme"].get<std::string>();
             if (layer.value().contains("style"))
               curField.style = layer.value()["style"].get<std::string>();
+            if (layer.value().contains("pointsize"))
+              curField.pointSize = std::max(
+                  0, std::min(50, layer.value()["pointsize"].get<int>()));
             if (curField.name.size() == 0) curField.name = curField.geomField;
             if (curField.id.size() == 0) curField.id = getFreeLayerId();
             ret.fields.push_back(curField);

--- a/web/script.js
+++ b/web/script.js
@@ -216,7 +216,10 @@ function loadLayers(id, numObjects, autoThreshold, layers) {
     for (layer of layers) {
         let prepedLayer = getLayer(id, layer, autoThreshold);
         if (prepedLayer) {
-            prepedLayer.layer.on('load', _onLayerLoad);
+            // NOTE: an "auto" layer is a LayerGroup, which never fires 'load'
+            // itself; listen on the tile layers inside it instead.
+            const onLoad = (l) => l.eachLayer ? l.eachLayer(onLoad) : l.on('load', _onLayerLoad);
+            onLoad(prepedLayer.layer);
             if (layer["toggle"] == "checkbox") {
                 themes["custom"].overlays[1].layers.push(prepedLayer);
             } else {

--- a/web/themelayer.js
+++ b/web/themelayer.js
@@ -168,7 +168,8 @@ L.Control.ThemeLayerSwitcher = L.Control.extend({
           ? `overlay-${themeKey}-${group.name}`
           : null;
 
-	  if (!have) {
+	  // radio groups start with their first entry, checkbox groups with all
+	  if (group.type !== 'radio' || !have) {
 		input.checked = true;
         group.type === 'radio'
           ? this._handleRadioGroup(group, entry.layer)


### PR DESCRIPTION
So far, a map with more than one layer never got rid of its "Loading results..." box, and only the first of its checkbox layers was shown. Points in the objects style were always drawn as 3x3 pixels. This change fixes the two bugs and makes the point size configurable.

- The loading box now listens on the tile layers inside an `auto` layer, since the `LayerGroup` around them never fires `load`
- Checkbox groups in the layer switcher now start with all entries enabled, radio groups still with their first one
- A per-layer `pointsize` in the query config sets the pixel radius of a point (default 1, at most 50) and is echoed in the `/query` response

NOTE: The `#+ result-plot:` parser in `sparql-results` has to know the new key as well, see IoannisNezis/sparql-results#1.